### PR TITLE
replace magic numbers in Template mapper

### DIFF
--- a/src/main/java/uk/gov/ons/census/notifyprocessor/utilities/TemplateMapper.java
+++ b/src/main/java/uk/gov/ons/census/notifyprocessor/utilities/TemplateMapper.java
@@ -7,7 +7,12 @@ import org.springframework.stereotype.Component;
 
 @Component
 public class TemplateMapper {
-
+  public static final int HOUSEHOLD_ENGLAND = 1;
+  public static final int HOUSEHOLD_WALES = 2;
+  public static final int HOUSEHOLD_NI = 4;
+  public static final int INDIVIDUAL_RESPONSE_ENGLAND = 21;
+  public static final int INDIVIDUAL_RESPONSE_WALES = 22;
+  public static final int INDIVIDUAL_RESPONSE_NI = 24;
   private final String HH_E;
   private final String HH_W;
   private final String HH_NI;
@@ -34,25 +39,26 @@ public class TemplateMapper {
     Tuple result = null;
     switch (fulfilmentCode) {
       case "UACHHT1":
-        result = new Tuple(1, HH_E);
+        result = new Tuple(HOUSEHOLD_ENGLAND, HH_E);
         break;
       case "UACHHT2":
       case "UACHHT2W":
-        result = new Tuple(2, HH_W);
+        result = new Tuple(HOUSEHOLD_WALES, HH_W);
         break;
       case "UACHHT4":
-        result = new Tuple(4, HH_NI);
+        result = new Tuple(HOUSEHOLD_NI, HH_NI);
         break;
       case "UACIT1":
-        result = new Tuple(21, IR_E);
+        result = new Tuple(INDIVIDUAL_RESPONSE_ENGLAND, IR_E);
         break;
       case "UACIT2":
       case "UACIT2W":
-        result = new Tuple(22, IR_W);
+        result = new Tuple(INDIVIDUAL_RESPONSE_WALES, IR_W);
         break;
       case "UACIT4":
-        result = new Tuple(24, IR_NI);
+        result = new Tuple(INDIVIDUAL_RESPONSE_NI, IR_NI);
         break;
+
       default:
         break;
     }
@@ -63,7 +69,6 @@ public class TemplateMapper {
   @Data
   @AllArgsConstructor
   public static class Tuple {
-
     public int questionnaireType;
     public String templateId;
   }

--- a/src/main/java/uk/gov/ons/census/notifyprocessor/utilities/TemplateMapper.java
+++ b/src/main/java/uk/gov/ons/census/notifyprocessor/utilities/TemplateMapper.java
@@ -7,12 +7,12 @@ import org.springframework.stereotype.Component;
 
 @Component
 public class TemplateMapper {
-  public static final int HOUSEHOLD_ENGLAND = 1;
-  public static final int HOUSEHOLD_WALES = 2;
-  public static final int HOUSEHOLD_NI = 4;
-  public static final int INDIVIDUAL_RESPONSE_ENGLAND = 21;
-  public static final int INDIVIDUAL_RESPONSE_WALES = 22;
-  public static final int INDIVIDUAL_RESPONSE_NI = 24;
+  private static final int HOUSEHOLD_ENGLAND = 1;
+  private static final int HOUSEHOLD_WALES = 2;
+  private static final int HOUSEHOLD_NI = 4;
+  private static final int INDIVIDUAL_RESPONSE_ENGLAND = 21;
+  private static final int INDIVIDUAL_RESPONSE_WALES = 22;
+  private static final int INDIVIDUAL_RESPONSE_NI = 24;
   private final String HH_E;
   private final String HH_W;
   private final String HH_NI;

--- a/src/test/java/uk/gov/ons/census/notifyprocessor/utilities/TemplateMapperTest.java
+++ b/src/test/java/uk/gov/ons/census/notifyprocessor/utilities/TemplateMapperTest.java
@@ -1,6 +1,7 @@
 package uk.gov.ons.census.notifyprocessor.utilities;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static uk.gov.ons.census.notifyprocessor.utilities.TemplateMapper.*;
 
 import org.junit.Test;
 import uk.gov.ons.census.notifyprocessor.utilities.TemplateMapper.Tuple;
@@ -14,14 +15,14 @@ public class TemplateMapperTest {
         new TemplateMapper(
             "TemplateA", "TemplateB", "TemplateC", "TemplateD", "TemplateE", "TemplateF");
 
-    testTemplate(underTest, "UACHHT1", 1, "TemplateA");
-    testTemplate(underTest, "UACHHT2", 2, "TemplateB");
-    testTemplate(underTest, "UACHHT2W", 2, "TemplateB");
-    testTemplate(underTest, "UACHHT4", 4, "TemplateC");
-    testTemplate(underTest, "UACIT1", 21, "TemplateD");
-    testTemplate(underTest, "UACIT2", 22, "TemplateE");
-    testTemplate(underTest, "UACIT2W", 22, "TemplateE");
-    testTemplate(underTest, "UACIT4", 24, "TemplateF");
+    testTemplate(underTest, "UACHHT1", HOUSEHOLD_ENGLAND, "TemplateA");
+    testTemplate(underTest, "UACHHT2", HOUSEHOLD_WALES, "TemplateB");
+    testTemplate(underTest, "UACHHT2W", HOUSEHOLD_WALES, "TemplateB");
+    testTemplate(underTest, "UACHHT4", HOUSEHOLD_NI, "TemplateC");
+    testTemplate(underTest, "UACIT1", INDIVIDUAL_RESPONSE_ENGLAND, "TemplateD");
+    testTemplate(underTest, "UACIT2", INDIVIDUAL_RESPONSE_WALES, "TemplateE");
+    testTemplate(underTest, "UACIT2W", INDIVIDUAL_RESPONSE_WALES, "TemplateE");
+    testTemplate(underTest, "UACIT4", INDIVIDUAL_RESPONSE_NI, "TemplateF");
     assertThat(underTest.getTemplate("Wibble")).isNull();
   }
 

--- a/src/test/java/uk/gov/ons/census/notifyprocessor/utilities/TemplateMapperTest.java
+++ b/src/test/java/uk/gov/ons/census/notifyprocessor/utilities/TemplateMapperTest.java
@@ -1,12 +1,17 @@
 package uk.gov.ons.census.notifyprocessor.utilities;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static uk.gov.ons.census.notifyprocessor.utilities.TemplateMapper.*;
 
 import org.junit.Test;
 import uk.gov.ons.census.notifyprocessor.utilities.TemplateMapper.Tuple;
 
 public class TemplateMapperTest {
+  private static final int HOUSEHOLD_ENGLAND = 1;
+  private static final int HOUSEHOLD_WALES = 2;
+  private static final int HOUSEHOLD_NI = 4;
+  private static final int INDIVIDUAL_RESPONSE_ENGLAND = 21;
+  private static final int INDIVIDUAL_RESPONSE_WALES = 22;
+  private static final int INDIVIDUAL_RESPONSE_NI = 24;
 
   @Test
   public void testGetTemplate() {


### PR DESCRIPTION
# Motivation and Context
Looked at this as part of https://trello.com/c/xem9Ksud/878-rmc-211a-handle-request-for-individual-uac-8
All the mapping work had already been done, but found the magic numbers mildly confusing and decided to fix them whilst looking at the code.  Very minor change, easy to do now.

# What has changed
Extracted magic numbers to Constants in the Template Mappings class.

# How to test?
Test with the new ATs and caseprocessor on the same ticket
https://github.com/ONSdigital/census-rm-case-processor/pull/42
https://github.com/ONSdigital/census-rm-acceptance-tests/tree/RMC-211-A-individual-uac-request-logging

# Links
https://trello.com/c/xem9Ksud/878-rmc-211a-handle-request-for-individual-uac-8

# Screenshots (if appropriate):