### PR TITLE
Reduce SMS templates to four

### DIFF
--- a/src/main/java/uk/gov/ons/census/notifyprocessor/utilities/TemplateMapper.java
+++ b/src/main/java/uk/gov/ons/census/notifyprocessor/utilities/TemplateMapper.java
@@ -13,50 +13,48 @@ public class TemplateMapper {
   private static final int INDIVIDUAL_RESPONSE_ENGLAND = 21;
   private static final int INDIVIDUAL_RESPONSE_WALES = 22;
   private static final int INDIVIDUAL_RESPONSE_NI = 24;
-  private final String HH_E;
-  private final String HH_W;
-  private final String HH_NI;
-  private final String IR_E;
-  private final String IR_W;
-  private final String IR_NI;
+  private final String templateEnglish;
+  private final String templateWelsh;
+  private final String templateWelshAndEnglish;
+  private final String templateNorthernIreland;
 
   public TemplateMapper(
-      @Value("${notify.templateIdReplacementHHE}") String HH_E,
-      @Value("${notify.templateIdReplacementHHW}") String HH_W,
-      @Value("${notify.templateIdReplacementHHNI}") String HH_NI,
-      @Value("${notify.templateIdIndividualResponseE}") String IR_E,
-      @Value("${notify.templateIdIndividualResponseW}") String IR_W,
-      @Value("${notify.templateIdIndividualResponseNI}") String IR_NI) {
-    this.HH_E = HH_E;
-    this.HH_W = HH_W;
-    this.HH_NI = HH_NI;
-    this.IR_E = IR_E;
-    this.IR_W = IR_W;
-    this.IR_NI = IR_NI;
+      @Value("${notify.templateEnglish}") String templateEnglish,
+      @Value("${notify.templateWelsh}") String templateWelsh,
+      @Value("${notify.templateWelshAndEnglish}") String templateWelshAndEnglish,
+      @Value("${notify.templateNorthernIreland}") String templateNorthernIreland) {
+    this.templateEnglish = templateEnglish;
+    this.templateWelsh = templateWelsh;
+    this.templateWelshAndEnglish = templateWelshAndEnglish;
+    this.templateNorthernIreland = templateNorthernIreland;
   }
 
   public Tuple getTemplate(String fulfilmentCode) {
     Tuple result = null;
     switch (fulfilmentCode) {
       case "UACHHT1":
-        result = new Tuple(HOUSEHOLD_ENGLAND, HH_E);
+        result = new Tuple(HOUSEHOLD_ENGLAND, templateEnglish);
         break;
       case "UACHHT2":
+        result = new Tuple(HOUSEHOLD_WALES, templateWelshAndEnglish);
+        break;
       case "UACHHT2W":
-        result = new Tuple(HOUSEHOLD_WALES, HH_W);
+        result = new Tuple(HOUSEHOLD_WALES, templateWelsh);
         break;
       case "UACHHT4":
-        result = new Tuple(HOUSEHOLD_NI, HH_NI);
+        result = new Tuple(HOUSEHOLD_NI, templateNorthernIreland);
         break;
       case "UACIT1":
-        result = new Tuple(INDIVIDUAL_RESPONSE_ENGLAND, IR_E);
+        result = new Tuple(INDIVIDUAL_RESPONSE_ENGLAND, templateEnglish);
         break;
       case "UACIT2":
+        result = new Tuple(INDIVIDUAL_RESPONSE_WALES, templateWelshAndEnglish);
+        break;
       case "UACIT2W":
-        result = new Tuple(INDIVIDUAL_RESPONSE_WALES, IR_W);
+        result = new Tuple(INDIVIDUAL_RESPONSE_WALES, templateWelsh);
         break;
       case "UACIT4":
-        result = new Tuple(INDIVIDUAL_RESPONSE_NI, IR_NI);
+        result = new Tuple(INDIVIDUAL_RESPONSE_NI, templateNorthernIreland);
         break;
 
       default:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -20,12 +20,10 @@ notify:
   apiKey: dummykey-ffffffff-ffff-ffff-ffff-ffffffffffff-ffffffff-ffff-ffff-ffff-ffffffffffff
   baseUrl: https://dummy-notify:123
   testMode: true
-  templateIdReplacementHHE: 21447bc2-e7c7-41ba-8c5e-7a5893068525
-  templateIdReplacementHHW: ef045f43-ffa8-4047-b8e2-65bfbce0f026
-  templateIdReplacementHHNI: 23f96daf-9674-4087-acfc-ffe98a52cf16
-  templateIdIndividualResponseE: 1ccd02a4-9b90-4234-ab7a-9215cb498f14
-  templateIdIndividualResponseW: 12dbc690-dc0e-4830-90bb-8a7d2282a521
-  templateIdIndividualResponseNI: eeed8619-2510-4871-a8c5-b442f574c358
+  templateEnglish: 21447bc2-e7c7-41ba-8c5e-7a5893068525
+  templateWelsh: ef045f43-ffa8-4047-b8e2-65bfbce0f026
+  templateWelshAndEnglish: 23f96daf-9674-4087-acfc-ffe98a52cf16
+  templateNorthernIreland: 1ccd02a4-9b90-4234-ab7a-9215cb498f14
   senderId: b7e75a6c-8f7f-4264-8b34-38bb5831270e
 
 caseapi:

--- a/src/test/java/uk/gov/ons/census/notifyprocessor/utilities/TemplateMapperTest.java
+++ b/src/test/java/uk/gov/ons/census/notifyprocessor/utilities/TemplateMapperTest.java
@@ -18,16 +18,19 @@ public class TemplateMapperTest {
 
     TemplateMapper underTest =
         new TemplateMapper(
-            "TemplateA", "TemplateB", "TemplateC", "TemplateD", "TemplateE", "TemplateF");
+            "TemplateEnglish",
+            "TemplateWelsh",
+            "TemplateWelshAndEnglish",
+            "TemplateNorthernIreland");
 
-    testTemplate(underTest, "UACHHT1", HOUSEHOLD_ENGLAND, "TemplateA");
-    testTemplate(underTest, "UACHHT2", HOUSEHOLD_WALES, "TemplateB");
-    testTemplate(underTest, "UACHHT2W", HOUSEHOLD_WALES, "TemplateB");
-    testTemplate(underTest, "UACHHT4", HOUSEHOLD_NI, "TemplateC");
-    testTemplate(underTest, "UACIT1", INDIVIDUAL_RESPONSE_ENGLAND, "TemplateD");
-    testTemplate(underTest, "UACIT2", INDIVIDUAL_RESPONSE_WALES, "TemplateE");
-    testTemplate(underTest, "UACIT2W", INDIVIDUAL_RESPONSE_WALES, "TemplateE");
-    testTemplate(underTest, "UACIT4", INDIVIDUAL_RESPONSE_NI, "TemplateF");
+    testTemplate(underTest, "UACHHT1", HOUSEHOLD_ENGLAND, "TemplateEnglish");
+    testTemplate(underTest, "UACHHT2", HOUSEHOLD_WALES, "TemplateWelshAndEnglish");
+    testTemplate(underTest, "UACHHT2W", HOUSEHOLD_WALES, "TemplateWelsh");
+    testTemplate(underTest, "UACHHT4", HOUSEHOLD_NI, "TemplateNorthernIreland");
+    testTemplate(underTest, "UACIT1", INDIVIDUAL_RESPONSE_ENGLAND, "TemplateEnglish");
+    testTemplate(underTest, "UACIT2", INDIVIDUAL_RESPONSE_WALES, "TemplateWelshAndEnglish");
+    testTemplate(underTest, "UACIT2W", INDIVIDUAL_RESPONSE_WALES, "TemplateWelsh");
+    testTemplate(underTest, "UACIT4", INDIVIDUAL_RESPONSE_NI, "TemplateNorthernIreland");
     assertThat(underTest.getTemplate("Wibble")).isNull();
   }
 


### PR DESCRIPTION
# Motivation and Context
We have finalised the copy for the SMS messages with new UAC codes, and there are just 4 different message variation.

# What has changed
Map fulfilment codes to SMS templates.

# How to test?
Run the acceptance tests.

# Links
Trello: https://trello.com/c/Qi9dXsKy