### PR TITLE
Enrich fulfilment messages with UAC and re-queue

### DIFF
--- a/src/main/java/uk/gov/ons/census/notifyprocessor/config/AppConfig.java
+++ b/src/main/java/uk/gov/ons/census/notifyprocessor/config/AppConfig.java
@@ -29,8 +29,16 @@ public class AppConfig {
   @Value("${queueconfig.fulfilment-request-inbound-queue}")
   private String fulfilmentInboundQueue;
 
+  @Value("${queueconfig.enriched-fulfilment-queue}")
+  private String enrichedFulfilmentQueue;
+
   @Bean
   public MessageChannel fulfilmentInputChannel() {
+    return new DirectChannel();
+  }
+
+  @Bean
+  public MessageChannel enrichedFulfilmentInputChannel() {
     return new DirectChannel();
   }
 
@@ -38,6 +46,15 @@ public class AppConfig {
   public AmqpInboundChannelAdapter fulfilmentInbound(
       @Qualifier("fulfilmentContainer") SimpleMessageListenerContainer listenerContainer,
       @Qualifier("fulfilmentInputChannel") MessageChannel channel) {
+    AmqpInboundChannelAdapter adapter = new AmqpInboundChannelAdapter(listenerContainer);
+    adapter.setOutputChannel(channel);
+    return adapter;
+  }
+
+  @Bean
+  public AmqpInboundChannelAdapter enrichedfulfilmentInbound(
+      @Qualifier("enrichedFulfilmentContainer") SimpleMessageListenerContainer listenerContainer,
+      @Qualifier("enrichedFulfilmentInputChannel") MessageChannel channel) {
     AmqpInboundChannelAdapter adapter = new AmqpInboundChannelAdapter(listenerContainer);
     adapter.setOutputChannel(channel);
     return adapter;
@@ -64,6 +81,16 @@ public class AppConfig {
     SimpleMessageListenerContainer container =
         new SimpleMessageListenerContainer(connectionFactory);
     container.setQueueNames(fulfilmentInboundQueue);
+    container.setConcurrentConsumers(consumers);
+    return container;
+  }
+
+  @Bean
+  public SimpleMessageListenerContainer enrichedFulfilmentContainer(
+      ConnectionFactory connectionFactory) {
+    SimpleMessageListenerContainer container =
+        new SimpleMessageListenerContainer(connectionFactory);
+    container.setQueueNames(enrichedFulfilmentQueue);
     container.setConcurrentConsumers(consumers);
     return container;
   }

--- a/src/main/java/uk/gov/ons/census/notifyprocessor/messaging/EnrichedFulfilmentRequestReceiver.java
+++ b/src/main/java/uk/gov/ons/census/notifyprocessor/messaging/EnrichedFulfilmentRequestReceiver.java
@@ -1,0 +1,23 @@
+package uk.gov.ons.census.notifyprocessor.messaging;
+
+import org.springframework.integration.annotation.MessageEndpoint;
+import org.springframework.integration.annotation.ServiceActivator;
+import org.springframework.transaction.annotation.Transactional;
+import uk.gov.ons.census.notifyprocessor.model.EnrichedFulfilmentRequest;
+import uk.gov.ons.census.notifyprocessor.service.EnrichedFulfilmentRequestService;
+
+@MessageEndpoint
+public class EnrichedFulfilmentRequestReceiver {
+  private final EnrichedFulfilmentRequestService enrichedFulfilmentRequestService;
+
+  public EnrichedFulfilmentRequestReceiver(
+      EnrichedFulfilmentRequestService enrichedFulfilmentRequestService) {
+    this.enrichedFulfilmentRequestService = enrichedFulfilmentRequestService;
+  }
+
+  @Transactional
+  @ServiceActivator(inputChannel = "enrichedFulfilmentInputChannel")
+  public void receiveMessage(EnrichedFulfilmentRequest enrichedFulfilmentRequest) {
+    enrichedFulfilmentRequestService.processMessage(enrichedFulfilmentRequest);
+  }
+}

--- a/src/main/java/uk/gov/ons/census/notifyprocessor/model/EnrichedFulfilmentRequest.java
+++ b/src/main/java/uk/gov/ons/census/notifyprocessor/model/EnrichedFulfilmentRequest.java
@@ -1,0 +1,10 @@
+package uk.gov.ons.census.notifyprocessor.model;
+
+import lombok.Data;
+
+@Data
+public class EnrichedFulfilmentRequest {
+  private String templateId;
+  private String mobileNumber;
+  private String uac;
+}

--- a/src/main/java/uk/gov/ons/census/notifyprocessor/service/EnrichedFulfilmentRequestService.java
+++ b/src/main/java/uk/gov/ons/census/notifyprocessor/service/EnrichedFulfilmentRequestService.java
@@ -1,0 +1,36 @@
+package uk.gov.ons.census.notifyprocessor.service;
+
+import java.util.Map;
+import java.util.UUID;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import uk.gov.ons.census.notifyprocessor.model.EnrichedFulfilmentRequest;
+import uk.gov.service.notify.NotificationClientApi;
+import uk.gov.service.notify.NotificationClientException;
+
+@Service
+public class EnrichedFulfilmentRequestService {
+
+  private String senderId;
+
+  private final NotificationClientApi notificationClient;
+
+  public EnrichedFulfilmentRequestService(
+      NotificationClientApi notificationClient, @Value("${notify.senderId}") String senderId) {
+    this.notificationClient = notificationClient;
+    this.senderId = senderId;
+  }
+
+  public void processMessage(EnrichedFulfilmentRequest fulfilmentRequest) {
+    try {
+      notificationClient.sendSms(
+          fulfilmentRequest.getTemplateId(),
+          fulfilmentRequest.getMobileNumber(),
+          Map.of("uac", fulfilmentRequest.getUac()),
+          UUID.randomUUID().toString(),
+          senderId);
+    } catch (NotificationClientException e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/src/main/java/uk/gov/ons/census/notifyprocessor/service/FulfilmentRequestService.java
+++ b/src/main/java/uk/gov/ons/census/notifyprocessor/service/FulfilmentRequestService.java
@@ -2,18 +2,16 @@ package uk.gov.ons.census.notifyprocessor.service;
 
 import java.util.Arrays;
 import java.util.HashSet;
-import java.util.Map;
 import java.util.Set;
-import java.util.UUID;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import uk.gov.ons.census.notifyprocessor.client.CaseClient;
+import uk.gov.ons.census.notifyprocessor.model.EnrichedFulfilmentRequest;
 import uk.gov.ons.census.notifyprocessor.model.ResponseManagementEvent;
 import uk.gov.ons.census.notifyprocessor.model.UacQidDTO;
 import uk.gov.ons.census.notifyprocessor.utilities.TemplateMapper;
 import uk.gov.ons.census.notifyprocessor.utilities.TemplateMapper.Tuple;
-import uk.gov.service.notify.NotificationClientApi;
-import uk.gov.service.notify.NotificationClientException;
 
 @Service
 public class FulfilmentRequestService {
@@ -30,27 +28,23 @@ public class FulfilmentRequestService {
               INDIVIDUAL_QUESTIONNAIRE_REQUEST_WALES_WELSH,
               INDIVIDUAL_QUESTIONNAIRE_REQUEST_NORTHERN_IRELAND));
 
-  private boolean testMode;
-
-  private String senderId;
-
-  private final NotificationClientApi notificationClient;
-
   private final CaseClient caseClient;
 
   private final TemplateMapper templateMapper;
 
+  private final RabbitTemplate rabbitTemplate;
+
+  private final String enrichedFulfilmentExchange;
+
   public FulfilmentRequestService(
-      NotificationClientApi notificationClient,
       CaseClient caseClient,
-      @Value("${notify.testMode}") boolean testMode,
-      @Value("${notify.senderId}") String senderId,
-      TemplateMapper templateMapper) {
-    this.notificationClient = notificationClient;
+      TemplateMapper templateMapper,
+      RabbitTemplate rabbitTemplate,
+      @Value("${queueconfig.enriched-fulfilment-exchange}") String enrichedFulfilmentExchange) {
     this.caseClient = caseClient;
-    this.testMode = testMode;
-    this.senderId = senderId;
     this.templateMapper = templateMapper;
+    this.rabbitTemplate = rabbitTemplate;
+    this.enrichedFulfilmentExchange = enrichedFulfilmentExchange;
   }
 
   public void processMessage(ResponseManagementEvent fulfilmentEvent) {
@@ -67,18 +61,13 @@ public class FulfilmentRequestService {
     }
 
     UacQidDTO uacqid = caseClient.getUacQid(caseId, tuple.getQuestionnaireType());
+    EnrichedFulfilmentRequest enrichedFulfilmentRequest = new EnrichedFulfilmentRequest();
+    enrichedFulfilmentRequest.setTemplateId(tuple.getTemplateId());
+    enrichedFulfilmentRequest.setMobileNumber(
+        fulfilmentEvent.getPayload().getFulfilmentRequest().getContact().getTelNo());
+    enrichedFulfilmentRequest.setUac(uacqid.getUac());
 
-    if (!testMode) {
-      try {
-        notificationClient.sendSms(
-            tuple.getTemplateId(),
-            fulfilmentEvent.getPayload().getFulfilmentRequest().getContact().getTelNo(),
-            Map.of("uac", uacqid.getUac()),
-            UUID.randomUUID().toString(),
-            senderId);
-      } catch (NotificationClientException e) {
-        throw new RuntimeException(e);
-      }
-    }
+    // Send a message to ourselves - in case Gov Notify is down
+    rabbitTemplate.convertAndSend(enrichedFulfilmentExchange, "", enrichedFulfilmentRequest);
   }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,6 +10,8 @@ queueconfig:
   case-event-exchange: events
   fulfilment-routing-key: event.fulfilment.request
   fulfilment-request-inbound-queue: notify.fulfilments
+  enriched-fulfilment-exchange: notify.enriched.fulfilment.exchange
+  enriched-fulfilment-queue: notify.enriched.fulfilment
   consumers: 50
 
 healthcheck:
@@ -19,7 +21,6 @@ healthcheck:
 notify:
   apiKey: dummykey-ffffffff-ffff-ffff-ffff-ffffffffffff-ffffffff-ffff-ffff-ffff-ffffffffffff
   baseUrl: https://dummy-notify:123
-  testMode: true
   templateEnglish: 21447bc2-e7c7-41ba-8c5e-7a5893068525
   templateWelsh: ef045f43-ffa8-4047-b8e2-65bfbce0f026
   templateWelshAndEnglish: 23f96daf-9674-4087-acfc-ffe98a52cf16

--- a/src/test/java/uk/gov/ons/census/notifyprocessor/messaging/EnrichedFulfilmentRequestReceiverTest.java
+++ b/src/test/java/uk/gov/ons/census/notifyprocessor/messaging/EnrichedFulfilmentRequestReceiverTest.java
@@ -1,0 +1,24 @@
+package uk.gov.ons.census.notifyprocessor.messaging;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import org.junit.Test;
+import uk.gov.ons.census.notifyprocessor.model.EnrichedFulfilmentRequest;
+import uk.gov.ons.census.notifyprocessor.service.EnrichedFulfilmentRequestService;
+
+public class EnrichedFulfilmentRequestReceiverTest {
+  @Test
+  public void testReceiveMessage() {
+    EnrichedFulfilmentRequestService enrichedFulfilmentRequestService =
+        mock(EnrichedFulfilmentRequestService.class);
+    EnrichedFulfilmentRequestReceiver underTest =
+        new EnrichedFulfilmentRequestReceiver(enrichedFulfilmentRequestService);
+
+    EnrichedFulfilmentRequest enrichedFulfilmentRequest = new EnrichedFulfilmentRequest();
+    underTest.receiveMessage(enrichedFulfilmentRequest);
+
+    verify(enrichedFulfilmentRequestService).processMessage(eq(enrichedFulfilmentRequest));
+  }
+}

--- a/src/test/java/uk/gov/ons/census/notifyprocessor/messaging/FulfilmentRequestReceiverTest.java
+++ b/src/test/java/uk/gov/ons/census/notifyprocessor/messaging/FulfilmentRequestReceiverTest.java
@@ -1,6 +1,5 @@
 package uk.gov.ons.census.notifyprocessor.messaging;
 
-import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;

--- a/src/test/java/uk/gov/ons/census/notifyprocessor/service/EnrichedFulfilmentRequestServiceTest.java
+++ b/src/test/java/uk/gov/ons/census/notifyprocessor/service/EnrichedFulfilmentRequestServiceTest.java
@@ -1,0 +1,54 @@
+package uk.gov.ons.census.notifyprocessor.service;
+
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Map;
+import org.jeasy.random.EasyRandom;
+import org.junit.Test;
+import uk.gov.ons.census.notifyprocessor.model.EnrichedFulfilmentRequest;
+import uk.gov.service.notify.NotificationClientApi;
+import uk.gov.service.notify.NotificationClientException;
+
+public class EnrichedFulfilmentRequestServiceTest {
+  @Test
+  public void testProcessMessage() throws NotificationClientException {
+    EasyRandom easyRandom = new EasyRandom();
+    NotificationClientApi notificationClientApi = mock(NotificationClientApi.class);
+    EnrichedFulfilmentRequestService underTest =
+        new EnrichedFulfilmentRequestService(notificationClientApi, "testSenderId");
+
+    EnrichedFulfilmentRequest enrichedFulfilmentRequest =
+        easyRandom.nextObject(EnrichedFulfilmentRequest.class);
+
+    underTest.processMessage(enrichedFulfilmentRequest);
+
+    Map<String, String> testMap = Map.of("uac", enrichedFulfilmentRequest.getUac());
+    verify(notificationClientApi)
+        .sendSms(
+            eq(enrichedFulfilmentRequest.getTemplateId()),
+            eq(enrichedFulfilmentRequest.getMobileNumber()),
+            eq(testMap),
+            anyString(),
+            eq("testSenderId"));
+  }
+
+  @Test(expected = RuntimeException.class)
+  public void testProcessMessageNotifyApiServiceFails() throws NotificationClientException {
+    EasyRandom easyRandom = new EasyRandom();
+    NotificationClientApi notificationClientApi = mock(NotificationClientApi.class);
+    EnrichedFulfilmentRequestService underTest =
+        new EnrichedFulfilmentRequestService(notificationClientApi, "testSenderId");
+    when(notificationClientApi.sendSms(
+            anyString(), anyString(), anyMap(), anyString(), anyString()))
+        .thenThrow(NotificationClientException.class);
+    EnrichedFulfilmentRequest enrichedFulfilmentRequest =
+        easyRandom.nextObject(EnrichedFulfilmentRequest.class);
+
+    underTest.processMessage(enrichedFulfilmentRequest);
+  }
+}

--- a/src/test/java/uk/gov/ons/census/notifyprocessor/service/FulfilmentRequestServiceTest.java
+++ b/src/test/java/uk/gov/ons/census/notifyprocessor/service/FulfilmentRequestServiceTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.when;
 import java.util.Map;
 import org.jeasy.random.EasyRandom;
 import org.junit.Test;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import uk.gov.ons.census.notifyprocessor.client.CaseClient;
 import uk.gov.ons.census.notifyprocessor.model.ResponseManagementEvent;
 import uk.gov.ons.census.notifyprocessor.model.UacQidDTO;
@@ -23,45 +24,35 @@ import uk.gov.service.notify.NotificationClientException;
 public class FulfilmentRequestServiceTest {
 
   @Test
-  public void testProcessMessage() throws NotificationClientException {
+  public void testProcessMessage() {
     EasyRandom easyRandom = new EasyRandom();
-    NotificationClientApi notificationClientApi = mock(NotificationClientApi.class);
     CaseClient caseClient = mock(CaseClient.class);
     UacQidDTO uacQidDTO = easyRandom.nextObject(UacQidDTO.class);
     TemplateMapper templateMapper = mock(TemplateMapper.class);
+    RabbitTemplate rabbitTemplate = mock(RabbitTemplate.class);
     when(caseClient.getUacQid(anyString(), anyInt())).thenReturn(uacQidDTO);
     when(templateMapper.getTemplate(anyString())).thenReturn(new Tuple(1, "testTemplate"));
     FulfilmentRequestService underTest =
-        new FulfilmentRequestService(
-            notificationClientApi, caseClient, false, "testSenderId", templateMapper);
+        new FulfilmentRequestService(caseClient, templateMapper, rabbitTemplate, "testExchange");
 
     ResponseManagementEvent event = easyRandom.nextObject(ResponseManagementEvent.class);
     event.getPayload().getFulfilmentRequest().setFulfilmentCode("UACHHT1");
 
     underTest.processMessage(event);
-    Map<String, String> testMap = Map.of("uac", uacQidDTO.getUac());
     verify(caseClient).getUacQid(eq(event.getPayload().getFulfilmentRequest().getCaseId()), eq(1));
-    verify(notificationClientApi)
-        .sendSms(
-            eq("testTemplate"),
-            eq(event.getPayload().getFulfilmentRequest().getContact().getTelNo()),
-            eq(testMap),
-            anyString(),
-            eq("testSenderId"));
   }
 
   @Test
-  public void testProcessIndividualRequestMessage() throws NotificationClientException {
+  public void testProcessIndividualRequestMessage() {
     EasyRandom easyRandom = new EasyRandom();
-    NotificationClientApi notificationClientApi = mock(NotificationClientApi.class);
     CaseClient caseClient = mock(CaseClient.class);
     UacQidDTO uacQidDTO = easyRandom.nextObject(UacQidDTO.class);
     TemplateMapper templateMapper = mock(TemplateMapper.class);
+    RabbitTemplate rabbitTemplate = mock(RabbitTemplate.class);
     when(caseClient.getUacQid(anyString(), anyInt())).thenReturn(uacQidDTO);
     when(templateMapper.getTemplate(anyString())).thenReturn(new Tuple(1, "testTemplate"));
     FulfilmentRequestService underTest =
-        new FulfilmentRequestService(
-            notificationClientApi, caseClient, false, "testSenderId", templateMapper);
+        new FulfilmentRequestService(caseClient, templateMapper, rabbitTemplate, "testExchange");
 
     ResponseManagementEvent event = easyRandom.nextObject(ResponseManagementEvent.class);
     event.getPayload().getFulfilmentRequest().setFulfilmentCode("UACIT1");
@@ -70,73 +61,18 @@ public class FulfilmentRequestServiceTest {
     Map<String, String> testMap = Map.of("uac", uacQidDTO.getUac());
     verify(caseClient)
         .getUacQid(eq(event.getPayload().getFulfilmentRequest().getIndividualCaseId()), eq(1));
-    verify(notificationClientApi)
-        .sendSms(
-            eq("testTemplate"),
-            eq(event.getPayload().getFulfilmentRequest().getContact().getTelNo()),
-            eq(testMap),
-            anyString(),
-            eq("testSenderId"));
-  }
-
-  @Test
-  public void testProcessMessageTestMode() throws NotificationClientException {
-    EasyRandom easyRandom = new EasyRandom();
-    NotificationClientApi notificationClientApi = mock(NotificationClientApi.class);
-    CaseClient caseClient = mock(CaseClient.class);
-    UacQidDTO uacQidDTO = easyRandom.nextObject(UacQidDTO.class);
-    TemplateMapper templateMapper = mock(TemplateMapper.class);
-    when(templateMapper.getTemplate(anyString())).thenReturn(new Tuple(1, "testTemplate"));
-    when(caseClient.getUacQid(anyString(), anyInt())).thenReturn(uacQidDTO);
-
-    FulfilmentRequestService underTest =
-        new FulfilmentRequestService(
-            notificationClientApi, caseClient, true, "testSenderId", templateMapper);
-
-    ResponseManagementEvent event = easyRandom.nextObject(ResponseManagementEvent.class);
-    event.getPayload().getFulfilmentRequest().setFulfilmentCode("UACHHT1");
-
-    underTest.processMessage(event);
-    verify(caseClient).getUacQid(eq(event.getPayload().getFulfilmentRequest().getCaseId()), eq(1));
-    verify(notificationClientApi, never())
-        .sendSms(anyString(), anyString(), anyMap(), anyString(), anyString());
   }
 
   @Test(expected = RuntimeException.class)
-  public void testProcessMessageCaseNotFound() throws NotificationClientException {
+  public void testProcessMessageCaseNotFound() {
     EasyRandom easyRandom = new EasyRandom();
-    NotificationClientApi notificationClientApi = mock(NotificationClientApi.class);
     CaseClient caseClient = mock(CaseClient.class);
+    RabbitTemplate rabbitTemplate = mock(RabbitTemplate.class);
     TemplateMapper templateMapper = mock(TemplateMapper.class);
     when(templateMapper.getTemplate(anyString())).thenReturn(new Tuple(1, "testTemplate"));
     when(caseClient.getUacQid(anyString(), anyInt())).thenThrow(RuntimeException.class);
-
     FulfilmentRequestService underTest =
-        new FulfilmentRequestService(
-            notificationClientApi, caseClient, false, "testSenderId", templateMapper);
-
-    ResponseManagementEvent event = easyRandom.nextObject(ResponseManagementEvent.class);
-    event.getPayload().getFulfilmentRequest().setFulfilmentCode("UACHHT1");
-
-    underTest.processMessage(event);
-  }
-
-  @Test(expected = RuntimeException.class)
-  public void testProcessMessageNotifyApiServiceFails() throws NotificationClientException {
-    EasyRandom easyRandom = new EasyRandom();
-    NotificationClientApi notificationClientApi = mock(NotificationClientApi.class);
-    CaseClient caseClient = mock(CaseClient.class);
-    UacQidDTO uacQidDTO = easyRandom.nextObject(UacQidDTO.class);
-    TemplateMapper templateMapper = mock(TemplateMapper.class);
-    when(templateMapper.getTemplate(anyString())).thenReturn(new Tuple(1, "testTemplate"));
-    when(caseClient.getUacQid(anyString(), anyInt())).thenReturn(uacQidDTO);
-    when(notificationClientApi.sendSms(
-            anyString(), anyString(), anyMap(), anyString(), anyString()))
-        .thenThrow(NotificationClientException.class);
-
-    FulfilmentRequestService underTest =
-        new FulfilmentRequestService(
-            notificationClientApi, caseClient, false, "testSenderId", templateMapper);
+        new FulfilmentRequestService(caseClient, templateMapper, rabbitTemplate, "testExchange");
 
     ResponseManagementEvent event = easyRandom.nextObject(ResponseManagementEvent.class);
     event.getPayload().getFulfilmentRequest().setFulfilmentCode("UACHHT1");
@@ -151,11 +87,10 @@ public class FulfilmentRequestServiceTest {
     CaseClient caseClient = mock(CaseClient.class);
     UacQidDTO uacQidDTO = easyRandom.nextObject(UacQidDTO.class);
     TemplateMapper templateMapper = mock(TemplateMapper.class);
+    RabbitTemplate rabbitTemplate = mock(RabbitTemplate.class);
     when(caseClient.getUacQid(anyString(), anyInt())).thenReturn(uacQidDTO);
-
     FulfilmentRequestService underTest =
-        new FulfilmentRequestService(
-            notificationClientApi, caseClient, true, "testSenderId", templateMapper);
+        new FulfilmentRequestService(caseClient, templateMapper, rabbitTemplate, "testExchange");
 
     ResponseManagementEvent event = easyRandom.nextObject(ResponseManagementEvent.class);
     event.getPayload().getFulfilmentRequest().setFulfilmentCode("Wibble");

--- a/src/test/resources/definitions.json
+++ b/src/test/resources/definitions.json
@@ -32,6 +32,13 @@
       "durable": true,
       "auto_delete": false,
       "arguments": {}
+    },
+    {
+      "name": "notify.enriched.fulfilment",
+      "vhost": "/",
+      "durable": true,
+      "auto_delete": false,
+      "arguments": {}
     }
   ],
   "exchanges": [
@@ -39,6 +46,15 @@
       "name": "events",
       "vhost": "/",
       "type": "topic",
+      "durable": true,
+      "auto_delete": false,
+      "internal": false,
+      "arguments": {}
+    },
+    {
+      "name": "notify.enriched.fulfilment.exchange",
+      "vhost": "/",
+      "type": "direct",
       "durable": true,
       "auto_delete": false,
       "internal": false,
@@ -52,6 +68,14 @@
       "destination": "notify.fulfilments",
       "destination_type": "queue",
       "routing_key": "event.fulfilment.request",
+      "arguments": {}
+    },
+    {
+      "source": "notify.enriched.fulfilment.exchange",
+      "vhost": "/",
+      "destination": "notify.enriched.fulfilment",
+      "destination_type": "queue",
+      "routing_key": "",
       "arguments": {}
     }
   ]


### PR DESCRIPTION
# Motivation and Context
If Gov Notify is down then we will end up creating bazillions of UAC-QID pairs, because we create a pair every time we attempt to process a fulfilment message and we don't roll back the transaction, because it's not participating in a distributed transaction.

# What has changed
Notify Processor sends a message back to itself with a 'enriched' data, containing everything that's needed to be sent to Gov Notify, which can happily sit on the queue until Gov Notify is up again.

# How to test?
Run the acceptance tests. There should be zero regression. Try stopping the Notify Stub. Check that bazillions of UAC-QID pairs are not created.

# Links
Trello: https://trello.com/c/9rrv68nL