### PR TITLE
Fix for strict JSON checking

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11-slim
+FROM openjdk:11-jdk-slim
 
 ARG JAR_FILE=census-rm-notify-processor*.jar
 COPY target/$JAR_FILE /opt/census-rm-notify-processor.jar

--- a/src/main/java/uk/gov/ons/census/notifyprocessor/config/AppConfig.java
+++ b/src/main/java/uk/gov/ons/census/notifyprocessor/config/AppConfig.java
@@ -1,5 +1,6 @@
 package uk.gov.ons.census.notifyprocessor.config;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import java.util.TimeZone;
@@ -75,6 +76,7 @@ public class AppConfig {
   public Jackson2JsonMessageConverter messageConverter() {
     ObjectMapper objectMapper = new ObjectMapper();
     objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+    objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
     return new Jackson2JsonMessageConverter(objectMapper);
   }
 


### PR DESCRIPTION
# Motivation and Context
We can't handle messages from FWMT due to strict JSON checking

# What has changed
Disabled strict JSON checking.

# How to test?
Hard to reproduce, but try this message:
```
{"event":{"type":"FULFILMENT_REQUESTED","source":"FIELDWORK_GATEWAY","channel":"FIELD","dateTime":"2019-09-13T14:22:34.327Z","transactionId":"3287c518-1898-406c-b55e-1e6138678550"},"payload":{"fulfilmentRequest":{"fulfilmentCode":"P_OR_H1","caseId":"02606dca-7f75-e911-abc4-0003ff39541c","address":{},"contact":{"title":null,"forename":null,"surname":null,"telNo":null}}}}
```

# Links
Trello: https://trello.com/c/MKGPgxP8