### PR TITLE
Format UAC code to make it more readable

### DIFF
--- a/src/main/java/uk/gov/ons/census/notifyprocessor/service/FulfilmentRequestService.java
+++ b/src/main/java/uk/gov/ons/census/notifyprocessor/service/FulfilmentRequestService.java
@@ -65,7 +65,12 @@ public class FulfilmentRequestService {
     enrichedFulfilmentRequest.setTemplateId(tuple.getTemplateId());
     enrichedFulfilmentRequest.setMobileNumber(
         fulfilmentEvent.getPayload().getFulfilmentRequest().getContact().getTelNo());
-    enrichedFulfilmentRequest.setUac(uacqid.getUac());
+    String uac = uacqid.getUac();
+    String formattedUac =
+        String.format(
+            "%s %s %s %s",
+            uac.substring(0, 4), uac.substring(4, 8), uac.substring(8, 12), uac.substring(12, 16));
+    enrichedFulfilmentRequest.setUac(formattedUac.toUpperCase());
 
     // Send a message to ourselves - in case Gov Notify is down
     rabbitTemplate.convertAndSend(enrichedFulfilmentExchange, "", enrichedFulfilmentRequest);

--- a/src/test/java/uk/gov/ons/census/notifyprocessor/messaging/FulfilmentRequestReceiverIT.java
+++ b/src/test/java/uk/gov/ons/census/notifyprocessor/messaging/FulfilmentRequestReceiverIT.java
@@ -72,7 +72,7 @@ public class FulfilmentRequestReceiverIT {
 
     UacQidDTO uacQidDTO = new UacQidDTO();
     uacQidDTO.setQid("test QID");
-    uacQidDTO.setUac("test UAC");
+    uacQidDTO.setUac("aaaabbbbccccdddd");
 
     String returnJson = objectMapper.writeValueAsString(uacQidDTO);
 

--- a/src/test/java/uk/gov/ons/census/notifyprocessor/service/FulfilmentRequestServiceTest.java
+++ b/src/test/java/uk/gov/ons/census/notifyprocessor/service/FulfilmentRequestServiceTest.java
@@ -1,7 +1,7 @@
 package uk.gov.ons.census.notifyprocessor.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -12,14 +12,14 @@ import static org.mockito.Mockito.when;
 import java.util.Map;
 import org.jeasy.random.EasyRandom;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import uk.gov.ons.census.notifyprocessor.client.CaseClient;
+import uk.gov.ons.census.notifyprocessor.model.EnrichedFulfilmentRequest;
 import uk.gov.ons.census.notifyprocessor.model.ResponseManagementEvent;
 import uk.gov.ons.census.notifyprocessor.model.UacQidDTO;
 import uk.gov.ons.census.notifyprocessor.utilities.TemplateMapper;
 import uk.gov.ons.census.notifyprocessor.utilities.TemplateMapper.Tuple;
-import uk.gov.service.notify.NotificationClientApi;
-import uk.gov.service.notify.NotificationClientException;
 
 public class FulfilmentRequestServiceTest {
 
@@ -28,6 +28,7 @@ public class FulfilmentRequestServiceTest {
     EasyRandom easyRandom = new EasyRandom();
     CaseClient caseClient = mock(CaseClient.class);
     UacQidDTO uacQidDTO = easyRandom.nextObject(UacQidDTO.class);
+    uacQidDTO.setUac("aaaabbbbccccdddd");
     TemplateMapper templateMapper = mock(TemplateMapper.class);
     RabbitTemplate rabbitTemplate = mock(RabbitTemplate.class);
     when(caseClient.getUacQid(anyString(), anyInt())).thenReturn(uacQidDTO);
@@ -40,6 +41,13 @@ public class FulfilmentRequestServiceTest {
 
     underTest.processMessage(event);
     verify(caseClient).getUacQid(eq(event.getPayload().getFulfilmentRequest().getCaseId()), eq(1));
+    ArgumentCaptor<EnrichedFulfilmentRequest> enrichedFulfilmentRequestArgumentCaptor =
+        ArgumentCaptor.forClass(EnrichedFulfilmentRequest.class);
+    verify(rabbitTemplate)
+        .convertAndSend(eq("testExchange"), eq(""), enrichedFulfilmentRequestArgumentCaptor.capture());
+    EnrichedFulfilmentRequest actualEnrichedFulfilmentRequest =
+        enrichedFulfilmentRequestArgumentCaptor.getValue();
+    assertThat(actualEnrichedFulfilmentRequest.getUac()).isEqualTo("AAAA BBBB CCCC DDDD");
   }
 
   @Test
@@ -47,6 +55,7 @@ public class FulfilmentRequestServiceTest {
     EasyRandom easyRandom = new EasyRandom();
     CaseClient caseClient = mock(CaseClient.class);
     UacQidDTO uacQidDTO = easyRandom.nextObject(UacQidDTO.class);
+    uacQidDTO.setUac("aaaabbbbccccdddd");
     TemplateMapper templateMapper = mock(TemplateMapper.class);
     RabbitTemplate rabbitTemplate = mock(RabbitTemplate.class);
     when(caseClient.getUacQid(anyString(), anyInt())).thenReturn(uacQidDTO);
@@ -81,11 +90,11 @@ public class FulfilmentRequestServiceTest {
   }
 
   @Test
-  public void testProcessNonUacFulfilmentCode() throws NotificationClientException {
+  public void testProcessNonUacFulfilmentCode() {
     EasyRandom easyRandom = new EasyRandom();
-    NotificationClientApi notificationClientApi = mock(NotificationClientApi.class);
     CaseClient caseClient = mock(CaseClient.class);
     UacQidDTO uacQidDTO = easyRandom.nextObject(UacQidDTO.class);
+    uacQidDTO.setUac("aaaabbbbccccdddd");
     TemplateMapper templateMapper = mock(TemplateMapper.class);
     RabbitTemplate rabbitTemplate = mock(RabbitTemplate.class);
     when(caseClient.getUacQid(anyString(), anyInt())).thenReturn(uacQidDTO);
@@ -97,7 +106,5 @@ public class FulfilmentRequestServiceTest {
 
     underTest.processMessage(event);
     verify(caseClient, never()).getUacQid(anyString(), anyInt());
-    verify(notificationClientApi, never())
-        .sendSms(anyString(), anyString(), anyMap(), anyString(), anyString());
   }
 }

--- a/src/test/java/uk/gov/ons/census/notifyprocessor/service/FulfilmentRequestServiceTest.java
+++ b/src/test/java/uk/gov/ons/census/notifyprocessor/service/FulfilmentRequestServiceTest.java
@@ -44,7 +44,8 @@ public class FulfilmentRequestServiceTest {
     ArgumentCaptor<EnrichedFulfilmentRequest> enrichedFulfilmentRequestArgumentCaptor =
         ArgumentCaptor.forClass(EnrichedFulfilmentRequest.class);
     verify(rabbitTemplate)
-        .convertAndSend(eq("testExchange"), eq(""), enrichedFulfilmentRequestArgumentCaptor.capture());
+        .convertAndSend(
+            eq("testExchange"), eq(""), enrichedFulfilmentRequestArgumentCaptor.capture());
     EnrichedFulfilmentRequest actualEnrichedFulfilmentRequest =
         enrichedFulfilmentRequestArgumentCaptor.getValue();
     assertThat(actualEnrichedFulfilmentRequest.getUac()).isEqualTo("AAAA BBBB CCCC DDDD");


### PR DESCRIPTION
# Motivation and Context
The UAC code on the SMS message doesn't match the format of the printed letters.

# What has changed
Reformatted to be uppercase and with spaces in-between blocks of 4 characters.

# How to test?
Deploy to an environment with a Gov Notify and check the SMSs which are sent, or check the Gov Notify stub.

# Links
Trello: https://trello.com/c/iGzhi6UU