### PR TITLE
Add logging of details of Gov Notify API errors

### DIFF
--- a/src/main/java/uk/gov/ons/census/notifyprocessor/service/EnrichedFulfilmentRequestService.java
+++ b/src/main/java/uk/gov/ons/census/notifyprocessor/service/EnrichedFulfilmentRequestService.java
@@ -1,5 +1,7 @@
 package uk.gov.ons.census.notifyprocessor.service;
 
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
 import java.util.Map;
 import java.util.UUID;
 import org.springframework.beans.factory.annotation.Value;
@@ -10,6 +12,7 @@ import uk.gov.service.notify.NotificationClientException;
 
 @Service
 public class EnrichedFulfilmentRequestService {
+  private static final Logger log = LoggerFactory.getLogger(EnrichedFulfilmentRequestService.class);
 
   private String senderId;
 
@@ -30,6 +33,7 @@ public class EnrichedFulfilmentRequestService {
           UUID.randomUUID().toString(),
           senderId);
     } catch (NotificationClientException e) {
+      log.with("exception", e).error("Gov Notify sendSms error");
       throw new RuntimeException("Could not send SMS", e);
     }
   }


### PR DESCRIPTION
# Motivation and Context
We have no log detail when Gov Notify rejects a request to send an SMS. We need that detail to investigate unsendable messages.

# What has changed
Added logging of all the error details that we possess at the time of failure.

# How to test?
Try to reproduce one of the rejected messages on the quarantine queue.

# Links
Trello: https://trello.com/c/WfXHJLmc