### PR TITLE
Making dockerfile use a non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,13 @@
 FROM openjdk:11-jdk-slim
-
-ARG JAR_FILE=census-rm-notify-processor*.jar
-COPY target/$JAR_FILE /opt/census-rm-notify-processor.jar
+CMD ["/usr/local/openjdk-11/bin/java", "-jar", "/opt/census-rm-notify-processor.jar"]
 
 COPY healthcheck.sh /opt/healthcheck.sh
 RUN chmod +x /opt/healthcheck.sh
 
-CMD exec /usr/local/openjdk-11/bin/java $JAVA_OPTS -jar /opt/census-rm-notify-processor.jar
+RUN groupadd --gid 999 notifyprocessor && \
+    useradd --create-home --system --uid 999 --gid notifyprocessor notifyprocessor
+
+USER notifyprocessor
+
+ARG JAR_FILE=census-rm-notify-processor*.jar
+COPY target/$JAR_FILE /opt/census-rm-notify-processor.jar


### PR DESCRIPTION
# Motivation and Context
Running docker containers in root is a security concern so there should be a user that's created that the container can use instead. 

# What has changed
- Added a non-root user
- Updated dockerfile layout
# How to test?
- Run mvn clean install
- Run in docker dev environment with other prs
- Run in kubernetes environment with other prs

# Links
[Trello](https://trello.com/c/dUT7y0TW)