### PR TITLE
Rabbit msg persistence dlq config

### DIFF
--- a/src/main/java/uk/gov/ons/census/notifyprocessor/config/MessageConsumerConfig.java
+++ b/src/main/java/uk/gov/ons/census/notifyprocessor/config/MessageConsumerConfig.java
@@ -36,9 +36,6 @@ public class MessageConsumerConfig {
   @Value("${queueconfig.retry-delay}")
   private int retryDelay;
 
-  @Value("${queueconfig.retry-exchange}")
-  private String retryExchange;
-
   @Value("${queueconfig.quarantine-exchange}")
   private String quarantineExchange;
 
@@ -107,7 +104,6 @@ public class MessageConsumerConfig {
             logStackTraces,
             "Notify Processor",
             queueName,
-            retryExchange,
             quarantineExchange,
             rabbitTemplate);
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -15,7 +15,6 @@ queueconfig:
   consumers: 50
   retry-attempts: 3
   retry-delay: 1000 #milliseconds
-  retry-exchange: delayedRedeliveryExchange
   quarantine-exchange: quarantineExchange
 
 healthcheck:
@@ -43,3 +42,7 @@ exceptionmanager:
 
 messagelogging:
   logstacktraces: false
+
+logging:
+  level:
+    org.springframework.amqp.rabbit.listener.ConditionalRejectingErrorHandler: ERROR

--- a/src/test/resources/definitions.json
+++ b/src/test/resources/definitions.json
@@ -31,14 +31,30 @@
       "vhost": "/",
       "durable": true,
       "auto_delete": false,
-      "arguments": {}
+      "arguments": {
+        "x-dead-letter-exchange": "delayedRedeliveryExchange",
+        "x-dead-letter-routing-key": "notify.fulfilments"
+      }
     },
     {
       "name": "notify.enriched.fulfilment",
       "vhost": "/",
       "durable": true,
       "auto_delete": false,
-      "arguments": {}
+      "arguments": {
+        "x-dead-letter-exchange": "delayedRedeliveryExchange",
+        "x-dead-letter-routing-key": "notify.enriched.fulfilment"
+      }
+    },
+    {
+      "name": "delayedRedeliveryQueue",
+      "vhost": "/",
+      "durable": true,
+      "auto_delete": false,
+      "arguments": {
+        "x-dead-letter-exchange": "",
+        "x-message-ttl": 2000
+      }
     }
   ],
   "exchanges": [
@@ -59,6 +75,15 @@
       "auto_delete": false,
       "internal": false,
       "arguments": {}
+    },
+    {
+      "name": "delayedRedeliveryExchange",
+      "vhost": "/",
+      "type": "headers",
+      "durable": true,
+      "auto_delete": false,
+      "internal": false,
+      "arguments": {}
     }
   ],
   "bindings": [
@@ -74,6 +99,14 @@
       "source": "notify.enriched.fulfilment.exchange",
       "vhost": "/",
       "destination": "notify.enriched.fulfilment",
+      "destination_type": "queue",
+      "routing_key": "",
+      "arguments": {}
+    },
+    {
+      "source": "delayedRedeliveryExchange",
+      "vhost": "/",
+      "destination": "delayedRedeliveryQueue",
       "destination_type": "queue",
       "routing_key": "",
       "arguments": {}


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
We need to make RabbitMQ responsible for routing bad messages to a DLQ instead of manually doing this in our application code. This PR makes use of `AmqpRejectAndDontRequeueException` to reject a bad message, allowing Rabbit to take care of routing and redelivering that message.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
* Reject the message by throwing an exception
* Remove retry exchange from code 
* Suppress 'noisy' stack trace logging at warning level when the exception is thrown
*  Update tests and test queue config

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
Build this branch, checkout the [docker-dev PR](https://github.com/ONSdigital/census-rm-docker-dev/pull/40) and post a bad message to a queue this service consumes from. Check the message is redelivered continuously.

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
https://trello.com/c/hG9Mi8tA/315-rabbit-message-persistence-dlq-config-8