### PR TITLE
Persist quarantined messages

### DIFF
--- a/src/main/java/uk/gov/ons/census/notifyprocessor/config/MessageConsumerConfig.java
+++ b/src/main/java/uk/gov/ons/census/notifyprocessor/config/MessageConsumerConfig.java
@@ -39,9 +39,6 @@ public class MessageConsumerConfig {
   @Value("${queueconfig.retry-delay}")
   private int retryDelay;
 
-  @Value("${queueconfig.quarantine-exchange}")
-  private String quarantineExchange;
-
   @Value("${queueconfig.fulfilment-request-inbound-queue}")
   private String fulfilmentInboundQueue;
 

--- a/src/main/java/uk/gov/ons/census/notifyprocessor/config/MessageConsumerConfig.java
+++ b/src/main/java/uk/gov/ons/census/notifyprocessor/config/MessageConsumerConfig.java
@@ -5,7 +5,6 @@ import java.util.Map;
 import org.springframework.amqp.core.MessageProperties;
 import org.springframework.amqp.rabbit.config.RetryInterceptorBuilder;
 import org.springframework.amqp.rabbit.connection.ConnectionFactory;
-import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.amqp.rabbit.listener.AbstractMessageListenerContainer;
 import org.springframework.amqp.rabbit.listener.SimpleMessageListenerContainer;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -26,7 +25,6 @@ import uk.gov.ons.census.notifyprocessor.model.ResponseManagementEvent;
 @Configuration
 public class MessageConsumerConfig {
   private final ExceptionManagerClient exceptionManagerClient;
-  private final RabbitTemplate rabbitTemplate;
   private final ConnectionFactory connectionFactory;
 
   @Value("${messagelogging.logstacktraces}")
@@ -51,11 +49,8 @@ public class MessageConsumerConfig {
   private String enrichedFulfilmentQueue;
 
   public MessageConsumerConfig(
-      ExceptionManagerClient exceptionManagerClient,
-      RabbitTemplate rabbitTemplate,
-      ConnectionFactory connectionFactory) {
+      ExceptionManagerClient exceptionManagerClient, ConnectionFactory connectionFactory) {
     this.exceptionManagerClient = exceptionManagerClient;
-    this.rabbitTemplate = rabbitTemplate;
     this.connectionFactory = connectionFactory;
   }
 
@@ -104,9 +99,7 @@ public class MessageConsumerConfig {
             expectedMessageType,
             logStackTraces,
             "Notify Processor",
-            queueName,
-            quarantineExchange,
-            rabbitTemplate);
+            queueName);
 
     RetryOperationsInterceptor retryOperationsInterceptor =
         RetryInterceptorBuilder.stateless()

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -15,7 +15,6 @@ queueconfig:
   consumers: 50
   retry-attempts: 3
   retry-delay: 1000 #milliseconds
-  quarantine-exchange: quarantineExchange
 
 healthcheck:
   frequency: 1000 #milliseconds

--- a/src/test/java/uk/gov/ons/census/notifyprocessor/messaging/ManagedMessageRecovererTest.java
+++ b/src/test/java/uk/gov/ons/census/notifyprocessor/messaging/ManagedMessageRecovererTest.java
@@ -3,7 +3,6 @@ package uk.gov.ons.census.notifyprocessor.messaging;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -12,11 +11,9 @@ import static org.mockito.Mockito.when;
 import java.util.Map;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
-import org.mockito.InOrder;
 import org.springframework.amqp.AmqpRejectAndDontRequeueException;
 import org.springframework.amqp.core.Message;
 import org.springframework.amqp.core.MessageProperties;
-import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.amqp.rabbit.support.ListenerExecutionFailedException;
 import uk.gov.ons.census.notifyprocessor.client.ExceptionManagerClient;
 import uk.gov.ons.census.notifyprocessor.model.ExceptionReportResponse;
@@ -31,16 +28,9 @@ public class ManagedMessageRecovererTest {
   public void testRecover() {
     // Given
     ExceptionManagerClient exceptionManagerClient = mock(ExceptionManagerClient.class);
-    RabbitTemplate rabbitTemplate = mock(RabbitTemplate.class);
     ManagedMessageRecoverer underTest =
         new ManagedMessageRecoverer(
-            exceptionManagerClient,
-            Object.class,
-            false,
-            "test service",
-            "test queue",
-            "test quarantine exchange",
-            rabbitTemplate);
+            exceptionManagerClient, Object.class, false, "test service", "test queue");
 
     Message message = new Message("test message body".getBytes(), new MessageProperties());
     Throwable cause = new Exception(new RuntimeException());
@@ -73,16 +63,9 @@ public class ManagedMessageRecovererTest {
   public void testRecoverExceptionManagerUnavailable() {
     // Given
     ExceptionManagerClient exceptionManagerClient = mock(ExceptionManagerClient.class);
-    RabbitTemplate rabbitTemplate = mock(RabbitTemplate.class);
     ManagedMessageRecoverer underTest =
         new ManagedMessageRecoverer(
-            exceptionManagerClient,
-            Object.class,
-            false,
-            "test service",
-            "test queue",
-            "test quarantine exchange",
-            rabbitTemplate);
+            exceptionManagerClient, Object.class, false, "test service", "test queue");
 
     Message message = new Message("test message body".getBytes(), new MessageProperties());
     Throwable cause = new Exception(new RuntimeException());
@@ -110,16 +93,9 @@ public class ManagedMessageRecovererTest {
   @Test
   public void testRecoverQuarantine() {
     ExceptionManagerClient exceptionManagerClient = mock(ExceptionManagerClient.class);
-    RabbitTemplate rabbitTemplate = mock(RabbitTemplate.class);
     ManagedMessageRecoverer underTest =
         new ManagedMessageRecoverer(
-            exceptionManagerClient,
-            Object.class,
-            false,
-            "test service",
-            "test queue",
-            "test quarantine exchange",
-            rabbitTemplate);
+            exceptionManagerClient, Object.class, false, "test service", "test queue");
 
     MessageProperties messageProperties = new MessageProperties();
     messageProperties.setContentType("test content type");
@@ -143,12 +119,9 @@ public class ManagedMessageRecovererTest {
         .reportException(
             eq(MESSAGE_HASH), eq("test service"), eq("test queue"), eq(cause.getCause()));
 
-    InOrder inOrder = inOrder(exceptionManagerClient, rabbitTemplate);
-
     ArgumentCaptor<SkippedMessage> skippedMessageArgumentCaptor =
         ArgumentCaptor.forClass(SkippedMessage.class);
-    inOrder
-        .verify(exceptionManagerClient)
+    verify(exceptionManagerClient)
         .storeMessageBeforeSkipping(skippedMessageArgumentCaptor.capture());
     SkippedMessage actualSkippedMessage = skippedMessageArgumentCaptor.getValue();
     assertThat(actualSkippedMessage.getMessageHash()).isEqualTo(MESSAGE_HASH);
@@ -160,28 +133,16 @@ public class ManagedMessageRecovererTest {
     assertThat(actualSkippedMessage.getRoutingKey()).isEqualTo("test received routing key");
     assertThat(actualSkippedMessage.getService()).isEqualTo("test service");
 
-    inOrder
-        .verify(rabbitTemplate)
-        .send(eq("test quarantine exchange"), eq("test queue"), eq(message));
-
     verifyNoMoreInteractions(exceptionManagerClient);
-    verifyNoMoreInteractions(rabbitTemplate);
   }
 
   @Test(expected = AmqpRejectAndDontRequeueException.class)
   public void testRecoverPeek() {
     // Given
     ExceptionManagerClient exceptionManagerClient = mock(ExceptionManagerClient.class);
-    RabbitTemplate rabbitTemplate = mock(RabbitTemplate.class);
     ManagedMessageRecoverer underTest =
         new ManagedMessageRecoverer(
-            exceptionManagerClient,
-            Object.class,
-            false,
-            "test service",
-            "test queue",
-            "test quarantine exchange",
-            rabbitTemplate);
+            exceptionManagerClient, Object.class, false, "test service", "test queue");
 
     MessageProperties messageProperties = new MessageProperties();
     messageProperties.setContentType("test content type");


### PR DESCRIPTION
# Motivation and Context
For speed of development during the rehearsal, we didn't make the Exception Manager persistent. We now need to have the service backed by a persistent data store instead of using a Rabbit queue to save the quarantined messages.

# What has changed
Added persistence.

# How to test?
Publish a bad message onto a Rabbit queue. Quarantine the bad message. Check the `exceptionmanager` database.

# Links
Trello: https://trello.com/c/sYuR2Vgw