### PR TITLE
Handle Gov Notify phone number validation errors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
     <dependency>
       <groupId>uk.gov.service.notify</groupId>
       <artifactId>notifications-java-client</artifactId>
-      <version>3.9.2-RELEASE</version>
+      <version>3.15.1-RELEASE</version>
     </dependency>
 
     <!--    Test Dependencies below this point -->

--- a/src/main/java/uk/gov/ons/census/notifyprocessor/service/EnrichedFulfilmentRequestService.java
+++ b/src/main/java/uk/gov/ons/census/notifyprocessor/service/EnrichedFulfilmentRequestService.java
@@ -1,5 +1,7 @@
 package uk.gov.ons.census.notifyprocessor.service;
 
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
 import java.util.Map;
 import java.util.UUID;
 import org.springframework.beans.factory.annotation.Value;
@@ -10,7 +12,16 @@ import uk.gov.service.notify.NotificationClientException;
 
 @Service
 public class EnrichedFulfilmentRequestService {
-  private String senderId;
+
+  private static final Logger log = LoggerFactory.getLogger(EnrichedFulfilmentRequestService.class);
+  public static final String BAD_REQUEST_ERROR = "BadRequestError";
+  public static final String VALIDATION_ERROR = "ValidationError";
+  private static final String CANNOT_SEND_INTERNATIONAL_MESSAGE =
+      "Cannot send to international mobile numbers";
+  private static final String PHONE_NUMBER_VALIDATION_FAIL_MESSAGE = "phone_number ";
+  public static final String PHONE_NUMBER_FAILED_VALIDATION =
+      "Phone number failed Gov Notify validation (SHOULD be caught upstream but wasn't)";
+  private final String senderId;
 
   private final NotificationClientApi notificationClient;
 
@@ -28,13 +39,36 @@ public class EnrichedFulfilmentRequestService {
           Map.of("uac", fulfilmentRequest.getUac()),
           UUID.randomUUID().toString(),
           senderId);
-    } catch (NotificationClientException e) {
+    } catch (NotificationClientException notificationClientException) {
+      handleNotificationClientException(notificationClientException);
+    }
+  }
+
+  private void handleNotificationClientException(
+      NotificationClientException notificationClientException) {
+    String exceptionMessage = notificationClientException.getMessage();
+
+    if (exceptionMessage.contains(BAD_REQUEST_ERROR)
+        && exceptionMessage.contains(CANNOT_SEND_INTERNATIONAL_MESSAGE)) {
+      log.with("problem", CANNOT_SEND_INTERNATIONAL_MESSAGE).warn(PHONE_NUMBER_FAILED_VALIDATION);
+    } else if (exceptionMessage.contains(VALIDATION_ERROR)
+        && exceptionMessage.contains(PHONE_NUMBER_VALIDATION_FAIL_MESSAGE)) {
+      String phoneNumberProblem =
+          exceptionMessage.substring(
+              exceptionMessage.indexOf(PHONE_NUMBER_VALIDATION_FAIL_MESSAGE));
+      phoneNumberProblem =
+          phoneNumberProblem.substring(
+              PHONE_NUMBER_VALIDATION_FAIL_MESSAGE.length(), phoneNumberProblem.indexOf("\""));
+
+      log.with("problem", phoneNumberProblem).warn(PHONE_NUMBER_FAILED_VALIDATION);
+    } else {
       throw new RuntimeException(
           String.format(
               "Gov Notify sendSms NotificationClientException error with status code %d and "
                   + "message: %s",
-              e.getHttpResult(), e.getMessage()),
-          e);
+              notificationClientException.getHttpResult(),
+              notificationClientException.getMessage()),
+          notificationClientException);
     }
   }
 }

--- a/src/test/java/uk/gov/ons/census/notifyprocessor/service/EnrichedFulfilmentRequestServiceTest.java
+++ b/src/test/java/uk/gov/ons/census/notifyprocessor/service/EnrichedFulfilmentRequestServiceTest.java
@@ -51,4 +51,46 @@ public class EnrichedFulfilmentRequestServiceTest {
 
     underTest.processMessage(enrichedFulfilmentRequest);
   }
+
+  @Test
+  public void testProcessMessageNotifyApiServiceFailsBadPhoneNumber()
+      throws NotificationClientException {
+    EasyRandom easyRandom = new EasyRandom();
+    NotificationClientApi notificationClientApi = mock(NotificationClientApi.class);
+    EnrichedFulfilmentRequestService underTest =
+        new EnrichedFulfilmentRequestService(notificationClientApi, "testSenderId");
+    NotificationClientException notificationClientException =
+        new NotificationClientException(
+            "Status code: 400 {\"errors\":[{\"error\":\"ValidationError\","
+                + "\"message\":\"phone_number Not a valid country prefix\"}],\"status_code\":400}");
+
+    when(notificationClientApi.sendSms(
+            anyString(), anyString(), anyMap(), anyString(), anyString()))
+        .thenThrow(notificationClientException);
+    EnrichedFulfilmentRequest enrichedFulfilmentRequest =
+        easyRandom.nextObject(EnrichedFulfilmentRequest.class);
+
+    underTest.processMessage(enrichedFulfilmentRequest);
+  }
+
+  @Test
+  public void testProcessMessageNotifyApiServiceFailsNonUkPhoneNumber()
+      throws NotificationClientException {
+    EasyRandom easyRandom = new EasyRandom();
+    NotificationClientApi notificationClientApi = mock(NotificationClientApi.class);
+    EnrichedFulfilmentRequestService underTest =
+        new EnrichedFulfilmentRequestService(notificationClientApi, "testSenderId");
+    NotificationClientException notificationClientException =
+        new NotificationClientException(
+            "Status code: 400 {\"errors\":[{\"error\":\"BadRequestError\","
+                + "\"message\":\"Cannot send to international mobile numbers\"}],\"status_code\":400}");
+
+    when(notificationClientApi.sendSms(
+            anyString(), anyString(), anyMap(), anyString(), anyString()))
+        .thenThrow(notificationClientException);
+    EnrichedFulfilmentRequest enrichedFulfilmentRequest =
+        easyRandom.nextObject(EnrichedFulfilmentRequest.class);
+
+    underTest.processMessage(enrichedFulfilmentRequest);
+  }
 }


### PR DESCRIPTION
# Motivation and Context
We will be sent garbage phone numbers from upstream. Gov Notify rejects garbage phone numbers. There's nothing we can do with the garbage, so we should throw it away, lest we endlessly annoy our operational support team.

# What has changed
Added checks for Gov Notify phone number validation failures. Log a warning and swallow the bad message.

# How to test?
Connect the service to the real Gov Notify with a valid API key. Send in UAC fulfilment messages with garbage phone numbers. Check the logs.

# Links
Trello: https://trello.com/c/9Yg9yniY