### PR TITLE
Request UAC via SMS (HH, Ind & CE1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,17 +58,17 @@ To run the service locally for debugging override the application.yml configurat
 notify:
   apiKey: dummykey-ffffffff-ffff-ffff-ffff-ffffffffffff-ffffffff-ffff-ffff-ffff-ffffffffffff
   baseUrl: http://localhost:8917
-  templateEnglishHouseHold: ce1e545e-f50f-455b-a394-88b49a36fa0c
-  templateWelshHouseHold: 67dc02ff-a667-4b21-8e4e-61dd28936b8c
-  templateWelshAndEnglishHouseHold: 2375c493-359d-4712-938e-bf97a641f18f
-  templateNorthernIrelandHouseHold: 5d985237-b446-492a-bd0a-f7368265282c
-  templateEnglishIndividualResponse: b7ec0cde-b55b-460a-a78a-cb80767acdca
-  templateWelshIndividualResponse: b2db05f0-d7d1-4b88-b3de-658495bd8a47
-  templateWelshAndEnglishIndividualResponse: f6de09f2-4d4c-4f62-82e3-b1a24e0cf910
-  templateNorthernIrelandIndividualResponse: d490af7d-300a-4eb8-a961-cb4de54332ee
-  templateEnglishCe: 21f22f8d-2642-444e-9d13-a54b87647a93
-  templateWelshCe: 2c12a125-4035-4b81-9988-204e02e759a5
-  templateWelshAndEnglishCe: b2b9e650-cb22-49d7-b5da-95169e13ea12
+  UACHHT1: ce1e545e-f50f-455b-a394-88b49a36fa0c
+  UACHHT2W: 67dc02ff-a667-4b21-8e4e-61dd28936b8c
+  UACHHT2: 2375c493-359d-4712-938e-bf97a641f18f
+  UACHHT4: 5d985237-b446-492a-bd0a-f7368265282c
+  UACIT1: b7ec0cde-b55b-460a-a78a-cb80767acdca
+  UACIT2W: b2db05f0-d7d1-4b88-b3de-658495bd8a47
+  UACIT2: f6de09f2-4d4c-4f62-82e3-b1a24e0cf910
+  UACIT4: d490af7d-300a-4eb8-a961-cb4de54332ee
+  UACCET1: 21f22f8d-2642-444e-9d13-a54b87647a93
+  UACCET2W: 2c12a125-4035-4b81-9988-204e02e759a5
+  UACCET2: b2b9e650-cb22-49d7-b5da-95169e13ea12
   senderId: ae14c5b3-f317-4051-834c-644f0c236347
 
 caseapi:

--- a/README.md
+++ b/README.md
@@ -10,14 +10,21 @@ This service connects to
 
 # Fulfilment codes
 
-The following fulfiment codes are currently supported.
+The following fulfilment codes are currently supported:
 
 | Detail | Code |
 |-----------------------------------------|-------:|
-|Individual questionnaire request England | UACIT1|
-|Individual questionnaire request Wales (English) | UACIT2|
-|Individual questionnaire request Wales (Welsh) | UACIT2W|
-|Individual questionnaire request Northern Ireland | UACIT4|
+|Household UAC England | UACHHT1|
+|Household UAC Wales (English) | UACHHT2|
+|Household UAC Wales (Welsh) | UACHHT2W|
+|Household UAC Northern Ireland | UACHHT4|
+|Individual UAC England | UACIT1|
+|Individual UAC Wales (English) | UACIT2|
+|Individual UAC Wales (Welsh) | UACIT2W|
+|Individual UAC Northern Ireland | UACIT4|
+|CE UAC England | UACCET1|
+|CE UAC Wales (English) | UACCET2|
+|CE UAC Wales (Welsh) | UACCET2W|
 
 # Overview
 
@@ -51,11 +58,18 @@ To run the service locally for debugging override the application.yml configurat
 notify:
   apiKey: dummykey-ffffffff-ffff-ffff-ffff-ffffffffffff-ffffffff-ffff-ffff-ffff-ffffffffffff
   baseUrl: http://localhost:8917
-  templateEnglish: 21447bc2-e7c7-41ba-8c5e-7a5893068525
-  templateWelsh: ef045f43-ffa8-4047-b8e2-65bfbce0f026
-  templateWelshAndEnglish: 23f96daf-9674-4087-acfc-ffe98a52cf16
-  templateNorthernIreland: 1ccd02a4-9b90-4234-ab7a-9215cb498f14
-  senderId: b7e75a6c-8f7f-4264-8b34-38bb5831270e
+  templateEnglishHouseHold: ce1e545e-f50f-455b-a394-88b49a36fa0c
+  templateWelshHouseHold: 67dc02ff-a667-4b21-8e4e-61dd28936b8c
+  templateWelshAndEnglishHouseHold: 2375c493-359d-4712-938e-bf97a641f18f
+  templateNorthernIrelandHouseHold: 5d985237-b446-492a-bd0a-f7368265282c
+  templateEnglishIndividualResponse: b7ec0cde-b55b-460a-a78a-cb80767acdca
+  templateWelshIndividualResponse: b2db05f0-d7d1-4b88-b3de-658495bd8a47
+  templateWelshAndEnglishIndividualResponse: f6de09f2-4d4c-4f62-82e3-b1a24e0cf910
+  templateNorthernIrelandIndividualResponse: d490af7d-300a-4eb8-a961-cb4de54332ee
+  templateEnglishCe: 21f22f8d-2642-444e-9d13-a54b87647a93
+  templateWelshCe: 2c12a125-4035-4b81-9988-204e02e759a5
+  templateWelshAndEnglishCe: b2b9e650-cb22-49d7-b5da-95169e13ea12
+  senderId: ae14c5b3-f317-4051-834c-644f0c236347
 
 caseapi:
   host: localhost

--- a/src/main/java/uk/gov/ons/census/notifyprocessor/service/FulfilmentRequestService.java
+++ b/src/main/java/uk/gov/ons/census/notifyprocessor/service/FulfilmentRequestService.java
@@ -13,12 +13,7 @@ import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import uk.gov.ons.census.notifyprocessor.cache.UacQidCache;
-import uk.gov.ons.census.notifyprocessor.model.EnrichedFulfilmentRequest;
-import uk.gov.ons.census.notifyprocessor.model.Event;
-import uk.gov.ons.census.notifyprocessor.model.Payload;
-import uk.gov.ons.census.notifyprocessor.model.ResponseManagementEvent;
-import uk.gov.ons.census.notifyprocessor.model.UacQid;
-import uk.gov.ons.census.notifyprocessor.model.UacQidCreated;
+import uk.gov.ons.census.notifyprocessor.model.*;
 import uk.gov.ons.census.notifyprocessor.utilities.TemplateMapper;
 import uk.gov.ons.census.notifyprocessor.utilities.TemplateMapper.Tuple;
 
@@ -69,7 +64,8 @@ public class FulfilmentRequestService {
 
     String caseId = fulfilmentEvent.getPayload().getFulfilmentRequest().getCaseId();
 
-    if (individualResponseRequestCodes.contains(fulfilmentCode)) {
+    if (individualResponseRequestCodes.contains(fulfilmentCode) &&
+            (fulfilmentEvent.getPayload().getFulfilmentRequest().getIndividualCaseId() != null)) {
       caseId = fulfilmentEvent.getPayload().getFulfilmentRequest().getIndividualCaseId();
     }
 

--- a/src/main/java/uk/gov/ons/census/notifyprocessor/service/FulfilmentRequestService.java
+++ b/src/main/java/uk/gov/ons/census/notifyprocessor/service/FulfilmentRequestService.java
@@ -65,7 +65,7 @@ public class FulfilmentRequestService {
     String caseId = fulfilmentEvent.getPayload().getFulfilmentRequest().getCaseId();
 
     if (individualResponseRequestCodes.contains(fulfilmentCode)
-        && (fulfilmentEvent.getPayload().getFulfilmentRequest().getIndividualCaseId() != null)) {
+        && fulfilmentEvent.getPayload().getFulfilmentRequest().getIndividualCaseId() != null) {
       caseId = fulfilmentEvent.getPayload().getFulfilmentRequest().getIndividualCaseId();
     }
 

--- a/src/main/java/uk/gov/ons/census/notifyprocessor/service/FulfilmentRequestService.java
+++ b/src/main/java/uk/gov/ons/census/notifyprocessor/service/FulfilmentRequestService.java
@@ -64,8 +64,8 @@ public class FulfilmentRequestService {
 
     String caseId = fulfilmentEvent.getPayload().getFulfilmentRequest().getCaseId();
 
-    if (individualResponseRequestCodes.contains(fulfilmentCode) &&
-            (fulfilmentEvent.getPayload().getFulfilmentRequest().getIndividualCaseId() != null)) {
+    if (individualResponseRequestCodes.contains(fulfilmentCode)
+        && (fulfilmentEvent.getPayload().getFulfilmentRequest().getIndividualCaseId() != null)) {
       caseId = fulfilmentEvent.getPayload().getFulfilmentRequest().getIndividualCaseId();
     }
 

--- a/src/main/java/uk/gov/ons/census/notifyprocessor/utilities/TemplateMapper.java
+++ b/src/main/java/uk/gov/ons/census/notifyprocessor/utilities/TemplateMapper.java
@@ -18,57 +18,78 @@ public class TemplateMapper {
   private static final int CE_ENGLAND = 31;
   private static final int CE_WALES = 32;
   private static final int CE_WALES_IN_WELSH = 33;
-  private final String templateEnglish;
-  private final String templateWelshAndEnglish;
-  private final String templateWelsh;
-  private final String templateNorthernIreland;
+  private final String templateEnglishHouseHold;
+  private final String templateWelshHouseHold;
+  private final String templateWelshAndEnglishHouseHold;
+  private final String templateNorthernIrelandHouseHold;
+  private final String templateEnglishIndividualResponse;
+  private final String templateWelshIndividualResponse;
+  private final String templateWelshAndEnglishIndividualResponse;
+  private final String templateNorthernIrelandIndividualResponse;
+  private final String templateEnglishCeManager;
+  private final String templateWelshCeManager;
+  private final String templateWelshAndEnglishCeManager;
 
   public TemplateMapper(
-      @Value("${notify.templateEnglish}") String templateEnglish,
-      @Value("${notify.templateWelsh}") String templateWelsh,
-      @Value("${notify.templateWelshAndEnglish}") String templateWelshAndEnglish,
-      @Value("${notify.templateNorthernIreland}") String templateNorthernIreland) {
-    this.templateEnglish = templateEnglish;
-    this.templateWelsh = templateWelsh;
-    this.templateWelshAndEnglish = templateWelshAndEnglish;
-    this.templateNorthernIreland = templateNorthernIreland;
+      @Value("${notify.templateEnglishHouseHold}") String templateEnglishHouseHold,
+      @Value("${notify.templateWelshHouseHold}") String templateWelshHouseHold,
+      @Value("${notify.templateWelshAndEnglishHouseHold}") String templateWelshAndEnglishHouseHold,
+      @Value("${notify.templateNorthernIrelandHouseHold}") String templateNorthernIrelandHouseHold,
+      @Value("${notify.templateEnglishIndividualResponse}") String templateEnglishIndividualResponse,
+      @Value("${notify.templateWelshIndividualResponse}") String templateWelshIndividualResponse,
+      @Value("${notify.templateWelshAndEnglishIndividualResponse}") String templateWelshAndEnglishIndividualResponse,
+      @Value("${notify.templateNorthernIrelandIndividualResponse}") String templateNorthernIrelandIndividualResponse,
+      @Value("${notify.templateEnglishCeManager}") String templateEnglishCeManager,
+      @Value("${notify.templateWelshCeManager}") String templateWelshCeManager,
+      @Value("${notify.templateWelshAndEnglishCeManager}") String templateWelshAndEnglishCeManager) {
+    this.templateEnglishHouseHold = templateEnglishHouseHold;
+    this.templateWelshHouseHold = templateWelshHouseHold;
+    this.templateWelshAndEnglishHouseHold = templateWelshAndEnglishHouseHold;
+    this.templateNorthernIrelandHouseHold = templateNorthernIrelandHouseHold;
+    this.templateEnglishIndividualResponse = templateEnglishIndividualResponse;
+    this.templateWelshIndividualResponse = templateWelshIndividualResponse;
+    this.templateWelshAndEnglishIndividualResponse = templateWelshAndEnglishIndividualResponse;
+    this.templateNorthernIrelandIndividualResponse = templateNorthernIrelandIndividualResponse;
+    this.templateEnglishCeManager = templateEnglishCeManager;
+    this.templateWelshCeManager = templateWelshCeManager;
+    this.templateWelshAndEnglishCeManager = templateWelshAndEnglishCeManager;
   }
 
   public Tuple getTemplate(String fulfilmentCode) {
     Tuple result = null;
     switch (fulfilmentCode) {
-      case "UACHHT1":
-        result = new Tuple(HOUSEHOLD_ENGLAND, templateEnglish);
+      case " UACHHT1":
+        result = new Tuple(HOUSEHOLD_ENGLAND, templateEnglishHouseHold);
         break;
       case "UACHHT2":
-        result = new Tuple(HOUSEHOLD_WALES, templateWelshAndEnglish);
+        result = new Tuple(HOUSEHOLD_WALES, templateWelshAndEnglishHouseHold);
         break;
       case "UACHHT2W":
-        result = new Tuple(HOUSEHOLD_WALES_IN_WELSH, templateWelsh);
+        result = new Tuple(HOUSEHOLD_WALES_IN_WELSH, templateWelshHouseHold);
         break;
       case "UACHHT4":
-        result = new Tuple(HOUSEHOLD_NI, templateNorthernIreland);
+        result = new Tuple(HOUSEHOLD_NI, templateNorthernIrelandHouseHold);
         break;
       case "UACIT1":
-        result = new Tuple(INDIVIDUAL_RESPONSE_ENGLAND, templateEnglish);
+        result = new Tuple(INDIVIDUAL_RESPONSE_ENGLAND, templateEnglishIndividualResponse);
         break;
       case "UACIT2":
-        result = new Tuple(INDIVIDUAL_RESPONSE_WALES, templateWelshAndEnglish);
+        result = new Tuple(INDIVIDUAL_RESPONSE_WALES, templateWelshAndEnglishIndividualResponse);
         break;
       case "UACIT2W":
-        result = new Tuple(INDIVIDUAL_RESPONSE_WALES_IN_WELSH, templateWelsh);
+        result = new Tuple(INDIVIDUAL_RESPONSE_WALES_IN_WELSH, templateWelshIndividualResponse);
         break;
       case "UACIT4":
-        result = new Tuple(INDIVIDUAL_RESPONSE_NI, templateNorthernIreland);
+        result = new Tuple(INDIVIDUAL_RESPONSE_NI, templateNorthernIrelandIndividualResponse);
         break;
       case "UACCET1":
-        result = new Tuple(CE_ENGLAND, templateEnglish);
+        result = new Tuple(CE_ENGLAND, templateEnglishCeManager);
         break;
       case "UACCET2":
-        result = new Tuple(CE_WALES, templateWelshAndEnglish);
+        result = new Tuple(CE_WALES, templateWelshAndEnglishCeManager);
         break;
       case "UACCET2W":
-        result = new Tuple(CE_WALES_IN_WELSH, templateWelsh);
+        result = new Tuple(CE_WALES_IN_WELSH, templateWelshCeManager);
         break;
 
       default:

--- a/src/main/java/uk/gov/ons/census/notifyprocessor/utilities/TemplateMapper.java
+++ b/src/main/java/uk/gov/ons/census/notifyprocessor/utilities/TemplateMapper.java
@@ -26,9 +26,9 @@ public class TemplateMapper {
   private final String templateWelshIndividualResponse;
   private final String templateWelshAndEnglishIndividualResponse;
   private final String templateNorthernIrelandIndividualResponse;
-  private final String templateEnglishCeManager;
-  private final String templateWelshCeManager;
-  private final String templateWelshAndEnglishCeManager;
+  private final String templateEnglishCe;
+  private final String templateWelshCe;
+  private final String templateWelshAndEnglishCe;
 
   public TemplateMapper(
       @Value("${notify.templateEnglishHouseHold}") String templateEnglishHouseHold,
@@ -39,9 +39,9 @@ public class TemplateMapper {
       @Value("${notify.templateWelshIndividualResponse}") String templateWelshIndividualResponse,
       @Value("${notify.templateWelshAndEnglishIndividualResponse}") String templateWelshAndEnglishIndividualResponse,
       @Value("${notify.templateNorthernIrelandIndividualResponse}") String templateNorthernIrelandIndividualResponse,
-      @Value("${notify.templateEnglishCeManager}") String templateEnglishCeManager,
-      @Value("${notify.templateWelshCeManager}") String templateWelshCeManager,
-      @Value("${notify.templateWelshAndEnglishCeManager}") String templateWelshAndEnglishCeManager) {
+      @Value("${notify.templateEnglishCe}") String templateEnglishCe,
+      @Value("${notify.templateWelshCe}") String templateWelshCe,
+      @Value("${notify.templateWelshAndEnglishCe}") String templateWelshAndEnglishCe) {
     this.templateEnglishHouseHold = templateEnglishHouseHold;
     this.templateWelshHouseHold = templateWelshHouseHold;
     this.templateWelshAndEnglishHouseHold = templateWelshAndEnglishHouseHold;
@@ -50,15 +50,15 @@ public class TemplateMapper {
     this.templateWelshIndividualResponse = templateWelshIndividualResponse;
     this.templateWelshAndEnglishIndividualResponse = templateWelshAndEnglishIndividualResponse;
     this.templateNorthernIrelandIndividualResponse = templateNorthernIrelandIndividualResponse;
-    this.templateEnglishCeManager = templateEnglishCeManager;
-    this.templateWelshCeManager = templateWelshCeManager;
-    this.templateWelshAndEnglishCeManager = templateWelshAndEnglishCeManager;
+    this.templateEnglishCe = templateEnglishCe;
+    this.templateWelshCe = templateWelshCe;
+    this.templateWelshAndEnglishCe = templateWelshAndEnglishCe;
   }
 
   public Tuple getTemplate(String fulfilmentCode) {
     Tuple result = null;
     switch (fulfilmentCode) {
-      case " UACHHT1":
+      case "UACHHT1":
         result = new Tuple(HOUSEHOLD_ENGLAND, templateEnglishHouseHold);
         break;
       case "UACHHT2":
@@ -83,13 +83,13 @@ public class TemplateMapper {
         result = new Tuple(INDIVIDUAL_RESPONSE_NI, templateNorthernIrelandIndividualResponse);
         break;
       case "UACCET1":
-        result = new Tuple(CE_ENGLAND, templateEnglishCeManager);
+        result = new Tuple(CE_ENGLAND, templateEnglishCe);
         break;
       case "UACCET2":
-        result = new Tuple(CE_WALES, templateWelshAndEnglishCeManager);
+        result = new Tuple(CE_WALES, templateWelshAndEnglishCe);
         break;
       case "UACCET2W":
-        result = new Tuple(CE_WALES_IN_WELSH, templateWelshCeManager);
+        result = new Tuple(CE_WALES_IN_WELSH, templateWelshCe);
         break;
 
       default:

--- a/src/main/java/uk/gov/ons/census/notifyprocessor/utilities/TemplateMapper.java
+++ b/src/main/java/uk/gov/ons/census/notifyprocessor/utilities/TemplateMapper.java
@@ -18,81 +18,78 @@ public class TemplateMapper {
   private static final int CE_ENGLAND = 31;
   private static final int CE_WALES = 32;
   private static final int CE_WALES_IN_WELSH = 33;
-  private final String templateEnglishHouseHold;
-  private final String templateWelshHouseHold;
-  private final String templateWelshAndEnglishHouseHold;
-  private final String templateNorthernIrelandHouseHold;
-  private final String templateEnglishIndividualResponse;
-  private final String templateWelshIndividualResponse;
-  private final String templateWelshAndEnglishIndividualResponse;
-  private final String templateNorthernIrelandIndividualResponse;
-  private final String templateEnglishCe;
-  private final String templateWelshCe;
-  private final String templateWelshAndEnglishCe;
+  private final String UACHHT1;
+  private final String UACHHT2W;
+  private final String UACHHT2;
+  private final String UACHHT4;
+  private final String UACIT1;
+  private final String UACIT2W;
+  private final String UACIT2;
+  private final String UACIT4;
+  private final String UACCET1;
+  private final String UACCET2W;
+  private final String UACCET2;
 
   public TemplateMapper(
-      @Value("${notify.templateEnglishHouseHold}") String templateEnglishHouseHold,
-      @Value("${notify.templateWelshHouseHold}") String templateWelshHouseHold,
-      @Value("${notify.templateWelshAndEnglishHouseHold}") String templateWelshAndEnglishHouseHold,
-      @Value("${notify.templateNorthernIrelandHouseHold}") String templateNorthernIrelandHouseHold,
-      @Value("${notify.templateEnglishIndividualResponse}")
-          String templateEnglishIndividualResponse,
-      @Value("${notify.templateWelshIndividualResponse}") String templateWelshIndividualResponse,
-      @Value("${notify.templateWelshAndEnglishIndividualResponse}")
-          String templateWelshAndEnglishIndividualResponse,
-      @Value("${notify.templateNorthernIrelandIndividualResponse}")
-          String templateNorthernIrelandIndividualResponse,
-      @Value("${notify.templateEnglishCe}") String templateEnglishCe,
-      @Value("${notify.templateWelshCe}") String templateWelshCe,
-      @Value("${notify.templateWelshAndEnglishCe}") String templateWelshAndEnglishCe) {
-    this.templateEnglishHouseHold = templateEnglishHouseHold;
-    this.templateWelshHouseHold = templateWelshHouseHold;
-    this.templateWelshAndEnglishHouseHold = templateWelshAndEnglishHouseHold;
-    this.templateNorthernIrelandHouseHold = templateNorthernIrelandHouseHold;
-    this.templateEnglishIndividualResponse = templateEnglishIndividualResponse;
-    this.templateWelshIndividualResponse = templateWelshIndividualResponse;
-    this.templateWelshAndEnglishIndividualResponse = templateWelshAndEnglishIndividualResponse;
-    this.templateNorthernIrelandIndividualResponse = templateNorthernIrelandIndividualResponse;
-    this.templateEnglishCe = templateEnglishCe;
-    this.templateWelshCe = templateWelshCe;
-    this.templateWelshAndEnglishCe = templateWelshAndEnglishCe;
+      @Value("${notify.UACHHT1}") String UACHHT1,
+      @Value("${notify.UACHHT2W}") String UACHHT2W,
+      @Value("${notify.UACHHT2}") String UACHHT2,
+      @Value("${notify.UACHHT4}") String UACHHT4,
+      @Value("${notify.UACIT1}") String UACIT1,
+      @Value("${notify.UACIT2W}") String UACIT2W,
+      @Value("${notify.UACIT2}") String UACIT2,
+      @Value("${notify.UACIT4}") String UACIT4,
+      @Value("${notify.UACCET1}") String UACCET1,
+      @Value("${notify.UACCET2W}") String UACCET2W,
+      @Value("${notify.UACCET2}") String UACCET2) {
+    this.UACHHT1 = UACHHT1;
+    this.UACHHT2W = UACHHT2W;
+    this.UACHHT2 = UACHHT2;
+    this.UACHHT4 = UACHHT4;
+    this.UACIT1 = UACIT1;
+    this.UACIT2W = UACIT2W;
+    this.UACIT2 = UACIT2;
+    this.UACIT4 = UACIT4;
+    this.UACCET1 = UACCET1;
+    this.UACCET2W = UACCET2W;
+    this.UACCET2 = UACCET2;
   }
 
   public Tuple getTemplate(String fulfilmentCode) {
     Tuple result = null;
     switch (fulfilmentCode) {
       case "UACHHT1":
-        result = new Tuple(HOUSEHOLD_ENGLAND, templateEnglishHouseHold);
+        result = new Tuple(HOUSEHOLD_ENGLAND, UACHHT1);
         break;
       case "UACHHT2":
-        result = new Tuple(HOUSEHOLD_WALES, templateWelshAndEnglishHouseHold);
+        result = new Tuple(HOUSEHOLD_WALES, UACHHT2);
         break;
       case "UACHHT2W":
-        result = new Tuple(HOUSEHOLD_WALES_IN_WELSH, templateWelshHouseHold);
+        result = new Tuple(HOUSEHOLD_WALES_IN_WELSH, UACHHT2W);
         break;
       case "UACHHT4":
-        result = new Tuple(HOUSEHOLD_NI, templateNorthernIrelandHouseHold);
+        result = new Tuple(HOUSEHOLD_NI, UACHHT4);
         break;
       case "UACIT1":
-        result = new Tuple(INDIVIDUAL_RESPONSE_ENGLAND, templateEnglishIndividualResponse);
+        result = new Tuple(INDIVIDUAL_RESPONSE_ENGLAND, UACIT1);
         break;
       case "UACIT2":
-        result = new Tuple(INDIVIDUAL_RESPONSE_WALES, templateWelshAndEnglishIndividualResponse);
+        result = new Tuple(INDIVIDUAL_RESPONSE_WALES, UACIT2);
         break;
       case "UACIT2W":
-        result = new Tuple(INDIVIDUAL_RESPONSE_WALES_IN_WELSH, templateWelshIndividualResponse);
+        result = new Tuple(INDIVIDUAL_RESPONSE_WALES_IN_WELSH, UACIT2W);
         break;
       case "UACIT4":
-        result = new Tuple(INDIVIDUAL_RESPONSE_NI, templateNorthernIrelandIndividualResponse);
+        result = new Tuple(INDIVIDUAL_RESPONSE_NI, UACIT4);
         break;
       case "UACCET1":
-        result = new Tuple(CE_ENGLAND, templateEnglishCe);
+        result = new Tuple(CE_ENGLAND, UACCET1);
         break;
       case "UACCET2":
-        result = new Tuple(CE_WALES, templateWelshAndEnglishCe);
+        result = new Tuple(CE_WALES, UACCET2);
         break;
       case "UACCET2W":
-        result = new Tuple(CE_WALES_IN_WELSH, templateWelshCe);
+        result = new Tuple(CE_WALES_IN_WELSH, UACCET2W);
         break;
 
       default:

--- a/src/main/java/uk/gov/ons/census/notifyprocessor/utilities/TemplateMapper.java
+++ b/src/main/java/uk/gov/ons/census/notifyprocessor/utilities/TemplateMapper.java
@@ -15,6 +15,9 @@ public class TemplateMapper {
   private static final int INDIVIDUAL_RESPONSE_WALES = 22;
   private static final int INDIVIDUAL_RESPONSE_WALES_IN_WELSH = 23;
   private static final int INDIVIDUAL_RESPONSE_NI = 24;
+  private static final int CE_ENGLAND = 31;
+  private static final int CE_WALES = 32;
+  private static final int CE_WALES_IN_WELSH = 33;
   private final String templateEnglish;
   private final String templateWelshAndEnglish;
   private final String templateWelsh;
@@ -57,6 +60,15 @@ public class TemplateMapper {
         break;
       case "UACIT4":
         result = new Tuple(INDIVIDUAL_RESPONSE_NI, templateNorthernIreland);
+        break;
+      case "UACCET1":
+        result = new Tuple(CE_ENGLAND, templateEnglish);
+        break;
+      case "UACCET2":
+        result = new Tuple(CE_WALES, templateWelshAndEnglish);
+        break;
+      case "UACCET2W":
+        result = new Tuple(CE_WALES_IN_WELSH, templateWelsh);
         break;
 
       default:

--- a/src/main/java/uk/gov/ons/census/notifyprocessor/utilities/TemplateMapper.java
+++ b/src/main/java/uk/gov/ons/census/notifyprocessor/utilities/TemplateMapper.java
@@ -35,10 +35,13 @@ public class TemplateMapper {
       @Value("${notify.templateWelshHouseHold}") String templateWelshHouseHold,
       @Value("${notify.templateWelshAndEnglishHouseHold}") String templateWelshAndEnglishHouseHold,
       @Value("${notify.templateNorthernIrelandHouseHold}") String templateNorthernIrelandHouseHold,
-      @Value("${notify.templateEnglishIndividualResponse}") String templateEnglishIndividualResponse,
+      @Value("${notify.templateEnglishIndividualResponse}")
+          String templateEnglishIndividualResponse,
       @Value("${notify.templateWelshIndividualResponse}") String templateWelshIndividualResponse,
-      @Value("${notify.templateWelshAndEnglishIndividualResponse}") String templateWelshAndEnglishIndividualResponse,
-      @Value("${notify.templateNorthernIrelandIndividualResponse}") String templateNorthernIrelandIndividualResponse,
+      @Value("${notify.templateWelshAndEnglishIndividualResponse}")
+          String templateWelshAndEnglishIndividualResponse,
+      @Value("${notify.templateNorthernIrelandIndividualResponse}")
+          String templateNorthernIrelandIndividualResponse,
       @Value("${notify.templateEnglishCe}") String templateEnglishCe,
       @Value("${notify.templateWelshCe}") String templateWelshCe,
       @Value("${notify.templateWelshAndEnglishCe}") String templateWelshAndEnglishCe) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -23,17 +23,17 @@ healthcheck:
 notify:
   apiKey: dummykey-ffffffff-ffff-ffff-ffff-ffffffffffff-ffffffff-ffff-ffff-ffff-ffffffffffff
   baseUrl: https://dummy-notify:123
-  templateEnglishHouseHold: ce1e545e-f50f-455b-a394-88b49a36fa0c
-  templateWelshHouseHold: 67dc02ff-a667-4b21-8e4e-61dd28936b8c
-  templateWelshAndEnglishHouseHold: 2375c493-359d-4712-938e-bf97a641f18f
-  templateNorthernIrelandHouseHold: 5d985237-b446-492a-bd0a-f7368265282c
-  templateEnglishIndividualResponse: b7ec0cde-b55b-460a-a78a-cb80767acdca
-  templateWelshIndividualResponse: b2db05f0-d7d1-4b88-b3de-658495bd8a47
-  templateWelshAndEnglishIndividualResponse: f6de09f2-4d4c-4f62-82e3-b1a24e0cf910
-  templateNorthernIrelandIndividualResponse: d490af7d-300a-4eb8-a961-cb4de54332ee
-  templateEnglishCe: 21f22f8d-2642-444e-9d13-a54b87647a93
-  templateWelshCe: 2c12a125-4035-4b81-9988-204e02e759a5
-  templateWelshAndEnglishCe: b2b9e650-cb22-49d7-b5da-95169e13ea12
+  UACHHT1: ce1e545e-f50f-455b-a394-88b49a36fa0c
+  UACHHT2W: 67dc02ff-a667-4b21-8e4e-61dd28936b8c
+  UACHHT2: 2375c493-359d-4712-938e-bf97a641f18f
+  UACHHT4: 5d985237-b446-492a-bd0a-f7368265282c
+  UACIT1: b7ec0cde-b55b-460a-a78a-cb80767acdca
+  UACIT2W: b2db05f0-d7d1-4b88-b3de-658495bd8a47
+  UACIT2: f6de09f2-4d4c-4f62-82e3-b1a24e0cf910
+  UACIT4: d490af7d-300a-4eb8-a961-cb4de54332ee
+  UACCET1: 21f22f8d-2642-444e-9d13-a54b87647a93
+  UACCET2W: 2c12a125-4035-4b81-9988-204e02e759a5
+  UACCET2: b2b9e650-cb22-49d7-b5da-95169e13ea12
   senderId: ae14c5b3-f317-4051-834c-644f0c236347
 
 uacservice:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -27,16 +27,13 @@ notify:
   templateWelshHouseHold: 67dc02ff-a667-4b21-8e4e-61dd28936b8c
   templateWelshAndEnglishHouseHold: 2375c493-359d-4712-938e-bf97a641f18f
   templateNorthernIrelandHouseHold: 5d985237-b446-492a-bd0a-f7368265282c
-
   templateEnglishIndividualResponse: b7ec0cde-b55b-460a-a78a-cb80767acdca
   templateWelshIndividualResponse: b2db05f0-d7d1-4b88-b3de-658495bd8a47
   templateWelshAndEnglishIndividualResponse: f6de09f2-4d4c-4f62-82e3-b1a24e0cf910
   templateNorthernIrelandIndividualResponse: d490af7d-300a-4eb8-a961-cb4de54332ee
-
-  templateEnglishCeManager: 21f22f8d-2642-444e-9d13-a54b87647a93
-  templateWelshCeManager: 2c12a125-4035-4b81-9988-204e02e759a5
-  templateWelshAndEnglishCeManager: b2b9e650-cb22-49d7-b5da-95169e13ea12
-
+  templateEnglishCe: 21f22f8d-2642-444e-9d13-a54b87647a93
+  templateWelshCe: 2c12a125-4035-4b81-9988-204e02e759a5
+  templateWelshAndEnglishCe: b2b9e650-cb22-49d7-b5da-95169e13ea12
   senderId: ae14c5b3-f317-4051-834c-644f0c236347
 
 uacservice:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -23,11 +23,21 @@ healthcheck:
 notify:
   apiKey: dummykey-ffffffff-ffff-ffff-ffff-ffffffffffff-ffffffff-ffff-ffff-ffff-ffffffffffff
   baseUrl: https://dummy-notify:123
-  templateEnglish: 21447bc2-e7c7-41ba-8c5e-7a5893068525
-  templateWelsh: ef045f43-ffa8-4047-b8e2-65bfbce0f026
-  templateWelshAndEnglish: 23f96daf-9674-4087-acfc-ffe98a52cf16
-  templateNorthernIreland: 1ccd02a4-9b90-4234-ab7a-9215cb498f14
-  senderId: b7e75a6c-8f7f-4264-8b34-38bb5831270e
+  templateEnglishHouseHold: ce1e545e-f50f-455b-a394-88b49a36fa0c
+  templateWelshHouseHold: 67dc02ff-a667-4b21-8e4e-61dd28936b8c
+  templateWelshAndEnglishHouseHold: 2375c493-359d-4712-938e-bf97a641f18f
+  templateNorthernIrelandHouseHold: 5d985237-b446-492a-bd0a-f7368265282c
+
+  templateEnglishIndividualResponse: b7ec0cde-b55b-460a-a78a-cb80767acdca
+  templateWelshIndividualResponse: b2db05f0-d7d1-4b88-b3de-658495bd8a47
+  templateWelshAndEnglishIndividualResponse: f6de09f2-4d4c-4f62-82e3-b1a24e0cf910
+  templateNorthernIrelandIndividualResponse: d490af7d-300a-4eb8-a961-cb4de54332ee
+
+  templateEnglishCeManager: 21f22f8d-2642-444e-9d13-a54b87647a93
+  templateWelshCeManager: 2c12a125-4035-4b81-9988-204e02e759a5
+  templateWelshAndEnglishCeManager: b2b9e650-cb22-49d7-b5da-95169e13ea12
+
+  senderId: ae14c5b3-f317-4051-834c-644f0c236347
 
 uacservice:
   connection:

--- a/src/test/java/uk/gov/ons/census/notifyprocessor/utilities/TemplateMapperTest.java
+++ b/src/test/java/uk/gov/ons/census/notifyprocessor/utilities/TemplateMapperTest.java
@@ -36,19 +36,23 @@ public class TemplateMapperTest {
             "TemplateWelshAndEnglishCe");
 
     testTemplate(underTest, "UACHHT1", HOUSEHOLD_ENGLAND, "TemplateEnglishHouseHold");
-    testTemplate(underTest, "UACHHT2", HOUSEHOLD_WALES,
-            "TemplateWelshAndEnglishHouseHold");
-    testTemplate(underTest, "UACHHT2W", HOUSEHOLD_WALES_IN_WELSH,
-            "TemplateWelshHouseHold");
+    testTemplate(underTest, "UACHHT2", HOUSEHOLD_WALES, "TemplateWelshAndEnglishHouseHold");
+    testTemplate(underTest, "UACHHT2W", HOUSEHOLD_WALES_IN_WELSH, "TemplateWelshHouseHold");
     testTemplate(underTest, "UACHHT4", HOUSEHOLD_NI, "TemplateNorthernIrelandHouseHold");
-    testTemplate(underTest, "UACIT1", INDIVIDUAL_RESPONSE_ENGLAND,
-            "TemplateEnglishIndividualResponse");
-    testTemplate(underTest, "UACIT2", INDIVIDUAL_RESPONSE_WALES,
-            "TemplateWelshAndEnglishIndividualResponse");
-    testTemplate(underTest, "UACIT2W", INDIVIDUAL_RESPONSE_WALES_IN_WELSH,
-            "TemplateWelshIndividualResponse");
-    testTemplate(underTest, "UACIT4", INDIVIDUAL_RESPONSE_NI,
-            "TemplateNorthernIrelandIndividualResponse");
+    testTemplate(
+        underTest, "UACIT1", INDIVIDUAL_RESPONSE_ENGLAND, "TemplateEnglishIndividualResponse");
+    testTemplate(
+        underTest,
+        "UACIT2",
+        INDIVIDUAL_RESPONSE_WALES,
+        "TemplateWelshAndEnglishIndividualResponse");
+    testTemplate(
+        underTest,
+        "UACIT2W",
+        INDIVIDUAL_RESPONSE_WALES_IN_WELSH,
+        "TemplateWelshIndividualResponse");
+    testTemplate(
+        underTest, "UACIT4", INDIVIDUAL_RESPONSE_NI, "TemplateNorthernIrelandIndividualResponse");
     testTemplate(underTest, "UACCET1", CE_ENGLAND, "TemplateEnglishCe");
     testTemplate(underTest, "UACCET2", CE_WALES, "TemplateWelshAndEnglishCe");
     testTemplate(underTest, "UACCET2W", CE_WALES_IN_WELSH, "TemplateWelshCe");

--- a/src/test/java/uk/gov/ons/census/notifyprocessor/utilities/TemplateMapperTest.java
+++ b/src/test/java/uk/gov/ons/census/notifyprocessor/utilities/TemplateMapperTest.java
@@ -36,13 +36,19 @@ public class TemplateMapperTest {
             "TemplateWelshAndEnglishCe");
 
     testTemplate(underTest, "UACHHT1", HOUSEHOLD_ENGLAND, "TemplateEnglishHouseHold");
-    testTemplate(underTest, "UACHHT2", HOUSEHOLD_WALES, "TemplateWelshAndEnglishHouseHold");
-    testTemplate(underTest, "UACHHT2W", HOUSEHOLD_WALES_IN_WELSH, "TemplateWelshHouseHold");
+    testTemplate(underTest, "UACHHT2", HOUSEHOLD_WALES,
+            "TemplateWelshAndEnglishHouseHold");
+    testTemplate(underTest, "UACHHT2W", HOUSEHOLD_WALES_IN_WELSH,
+            "TemplateWelshHouseHold");
     testTemplate(underTest, "UACHHT4", HOUSEHOLD_NI, "TemplateNorthernIrelandHouseHold");
-    testTemplate(underTest, "UACIT1", INDIVIDUAL_RESPONSE_ENGLAND, "TemplateEnglishIndividualResponse");
-    testTemplate(underTest, "UACIT2", INDIVIDUAL_RESPONSE_WALES, "TemplateWelshAndEnglishIndividualResponse");
-    testTemplate(underTest, "UACIT2W", INDIVIDUAL_RESPONSE_WALES_IN_WELSH, "TemplateWelshIndividualResponse");
-    testTemplate(underTest, "UACIT4", INDIVIDUAL_RESPONSE_NI, "TemplateNorthernIrelandIndividualResponse");
+    testTemplate(underTest, "UACIT1", INDIVIDUAL_RESPONSE_ENGLAND,
+            "TemplateEnglishIndividualResponse");
+    testTemplate(underTest, "UACIT2", INDIVIDUAL_RESPONSE_WALES,
+            "TemplateWelshAndEnglishIndividualResponse");
+    testTemplate(underTest, "UACIT2W", INDIVIDUAL_RESPONSE_WALES_IN_WELSH,
+            "TemplateWelshIndividualResponse");
+    testTemplate(underTest, "UACIT4", INDIVIDUAL_RESPONSE_NI,
+            "TemplateNorthernIrelandIndividualResponse");
     testTemplate(underTest, "UACCET1", CE_ENGLAND, "TemplateEnglishCe");
     testTemplate(underTest, "UACCET2", CE_WALES, "TemplateWelshAndEnglishCe");
     testTemplate(underTest, "UACCET2W", CE_WALES_IN_WELSH, "TemplateWelshCe");

--- a/src/test/java/uk/gov/ons/census/notifyprocessor/utilities/TemplateMapperTest.java
+++ b/src/test/java/uk/gov/ons/census/notifyprocessor/utilities/TemplateMapperTest.java
@@ -23,22 +23,29 @@ public class TemplateMapperTest {
 
     TemplateMapper underTest =
         new TemplateMapper(
-            "TemplateEnglish",
-            "TemplateWelsh",
-            "TemplateWelshAndEnglish",
-            "TemplateNorthernIreland");
+            "TemplateEnglishHouseHold",
+            "TemplateWelshHouseHold",
+            "TemplateWelshAndEnglishHouseHold",
+            "TemplateNorthernIrelandHouseHold",
+            "TemplateEnglishIndividualResponse",
+            "TemplateWelshIndividualResponse",
+            "TemplateWelshAndEnglishIndividualResponse",
+            "TemplateNorthernIrelandIndividualResponse",
+            "TemplateEnglishCeManager",
+            "TemplateWelshCeManager",
+            "TemplateWelshAndEnglishCeManager");
 
-    testTemplate(underTest, "UACHHT1", HOUSEHOLD_ENGLAND, "TemplateEnglish");
-    testTemplate(underTest, "UACHHT2", HOUSEHOLD_WALES, "TemplateWelshAndEnglish");
-    testTemplate(underTest, "UACHHT2W", HOUSEHOLD_WALES_IN_WELSH, "TemplateWelsh");
-    testTemplate(underTest, "UACHHT4", HOUSEHOLD_NI, "TemplateNorthernIreland");
-    testTemplate(underTest, "UACIT1", INDIVIDUAL_RESPONSE_ENGLAND, "TemplateEnglish");
-    testTemplate(underTest, "UACIT2", INDIVIDUAL_RESPONSE_WALES, "TemplateWelshAndEnglish");
-    testTemplate(underTest, "UACIT2W", INDIVIDUAL_RESPONSE_WALES_IN_WELSH, "TemplateWelsh");
-    testTemplate(underTest, "UACIT4", INDIVIDUAL_RESPONSE_NI, "TemplateNorthernIreland");
-    testTemplate(underTest, "UACCET1", CE_ENGLAND, "TemplateEnglish");
-    testTemplate(underTest, "UACCET2", CE_WALES, "TemplateWelshAndEnglish");
-    testTemplate(underTest, "UACCET2W", CE_WALES_IN_WELSH, "TemplateWelsh");
+    testTemplate(underTest, "UACHHT1", HOUSEHOLD_ENGLAND, "TemplateEnglishHouseHold");
+    testTemplate(underTest, "UACHHT2", HOUSEHOLD_WALES, "TemplateWelshAndEnglishHouseHold");
+    testTemplate(underTest, "UACHHT2W", HOUSEHOLD_WALES_IN_WELSH, "TemplateWelshHouseHold");
+    testTemplate(underTest, "UACHHT4", HOUSEHOLD_NI, "TemplateNorthernIrelandHouseHold");
+    testTemplate(underTest, "UACIT1", INDIVIDUAL_RESPONSE_ENGLAND, "TemplateEnglishIndividualResponse");
+    testTemplate(underTest, "UACIT2", INDIVIDUAL_RESPONSE_WALES, "TemplateWelshAndEnglishIndividualResponse");
+    testTemplate(underTest, "UACIT2W", INDIVIDUAL_RESPONSE_WALES_IN_WELSH, "TemplateWelshIndividualResponse");
+    testTemplate(underTest, "UACIT4", INDIVIDUAL_RESPONSE_NI, "TemplateNorthernIrelandIndividualResponse");
+    testTemplate(underTest, "UACCET1", CE_ENGLAND, "TemplateEnglishCeManager");
+    testTemplate(underTest, "UACCET2", CE_WALES, "TemplateWelshAndEnglishCeManager");
+    testTemplate(underTest, "UACCET2W", CE_WALES_IN_WELSH, "TemplateWelshCeManager");
     assertThat(underTest.getTemplate("Wibble")).isNull();
   }
 

--- a/src/test/java/uk/gov/ons/census/notifyprocessor/utilities/TemplateMapperTest.java
+++ b/src/test/java/uk/gov/ons/census/notifyprocessor/utilities/TemplateMapperTest.java
@@ -23,39 +23,29 @@ public class TemplateMapperTest {
 
     TemplateMapper underTest =
         new TemplateMapper(
-            "TemplateEnglishHouseHold",
-            "TemplateWelshHouseHold",
-            "TemplateWelshAndEnglishHouseHold",
-            "TemplateNorthernIrelandHouseHold",
-            "TemplateEnglishIndividualResponse",
-            "TemplateWelshIndividualResponse",
-            "TemplateWelshAndEnglishIndividualResponse",
-            "TemplateNorthernIrelandIndividualResponse",
-            "TemplateEnglishCe",
-            "TemplateWelshCe",
-            "TemplateWelshAndEnglishCe");
+            "UACHHT1",
+            "UACHHT2W",
+            "UACHHT2",
+            "UACHHT4",
+            "UACIT1",
+            "UACIT2W",
+            "UACIT2",
+            "UACIT4",
+            "UACCET1",
+            "UACCET2W",
+            "UACCET2");
 
-    testTemplate(underTest, "UACHHT1", HOUSEHOLD_ENGLAND, "TemplateEnglishHouseHold");
-    testTemplate(underTest, "UACHHT2", HOUSEHOLD_WALES, "TemplateWelshAndEnglishHouseHold");
-    testTemplate(underTest, "UACHHT2W", HOUSEHOLD_WALES_IN_WELSH, "TemplateWelshHouseHold");
-    testTemplate(underTest, "UACHHT4", HOUSEHOLD_NI, "TemplateNorthernIrelandHouseHold");
-    testTemplate(
-        underTest, "UACIT1", INDIVIDUAL_RESPONSE_ENGLAND, "TemplateEnglishIndividualResponse");
-    testTemplate(
-        underTest,
-        "UACIT2",
-        INDIVIDUAL_RESPONSE_WALES,
-        "TemplateWelshAndEnglishIndividualResponse");
-    testTemplate(
-        underTest,
-        "UACIT2W",
-        INDIVIDUAL_RESPONSE_WALES_IN_WELSH,
-        "TemplateWelshIndividualResponse");
-    testTemplate(
-        underTest, "UACIT4", INDIVIDUAL_RESPONSE_NI, "TemplateNorthernIrelandIndividualResponse");
-    testTemplate(underTest, "UACCET1", CE_ENGLAND, "TemplateEnglishCe");
-    testTemplate(underTest, "UACCET2", CE_WALES, "TemplateWelshAndEnglishCe");
-    testTemplate(underTest, "UACCET2W", CE_WALES_IN_WELSH, "TemplateWelshCe");
+    testTemplate(underTest, "UACHHT1", HOUSEHOLD_ENGLAND, "UACHHT1");
+    testTemplate(underTest, "UACHHT2", HOUSEHOLD_WALES, "UACHHT2");
+    testTemplate(underTest, "UACHHT2W", HOUSEHOLD_WALES_IN_WELSH, "UACHHT2W");
+    testTemplate(underTest, "UACHHT4", HOUSEHOLD_NI, "UACHHT4");
+    testTemplate(underTest, "UACIT1", INDIVIDUAL_RESPONSE_ENGLAND, "UACIT1");
+    testTemplate(underTest, "UACIT2", INDIVIDUAL_RESPONSE_WALES, "UACIT2");
+    testTemplate(underTest, "UACIT2W", INDIVIDUAL_RESPONSE_WALES_IN_WELSH, "UACIT2W");
+    testTemplate(underTest, "UACIT4", INDIVIDUAL_RESPONSE_NI, "UACIT4");
+    testTemplate(underTest, "UACCET1", CE_ENGLAND, "UACCET1");
+    testTemplate(underTest, "UACCET2", CE_WALES, "UACCET2");
+    testTemplate(underTest, "UACCET2W", CE_WALES_IN_WELSH, "UACCET2W");
     assertThat(underTest.getTemplate("Wibble")).isNull();
   }
 

--- a/src/test/java/uk/gov/ons/census/notifyprocessor/utilities/TemplateMapperTest.java
+++ b/src/test/java/uk/gov/ons/census/notifyprocessor/utilities/TemplateMapperTest.java
@@ -31,9 +31,9 @@ public class TemplateMapperTest {
             "TemplateWelshIndividualResponse",
             "TemplateWelshAndEnglishIndividualResponse",
             "TemplateNorthernIrelandIndividualResponse",
-            "TemplateEnglishCeManager",
-            "TemplateWelshCeManager",
-            "TemplateWelshAndEnglishCeManager");
+            "TemplateEnglishCe",
+            "TemplateWelshCe",
+            "TemplateWelshAndEnglishCe");
 
     testTemplate(underTest, "UACHHT1", HOUSEHOLD_ENGLAND, "TemplateEnglishHouseHold");
     testTemplate(underTest, "UACHHT2", HOUSEHOLD_WALES, "TemplateWelshAndEnglishHouseHold");
@@ -43,9 +43,9 @@ public class TemplateMapperTest {
     testTemplate(underTest, "UACIT2", INDIVIDUAL_RESPONSE_WALES, "TemplateWelshAndEnglishIndividualResponse");
     testTemplate(underTest, "UACIT2W", INDIVIDUAL_RESPONSE_WALES_IN_WELSH, "TemplateWelshIndividualResponse");
     testTemplate(underTest, "UACIT4", INDIVIDUAL_RESPONSE_NI, "TemplateNorthernIrelandIndividualResponse");
-    testTemplate(underTest, "UACCET1", CE_ENGLAND, "TemplateEnglishCeManager");
-    testTemplate(underTest, "UACCET2", CE_WALES, "TemplateWelshAndEnglishCeManager");
-    testTemplate(underTest, "UACCET2W", CE_WALES_IN_WELSH, "TemplateWelshCeManager");
+    testTemplate(underTest, "UACCET1", CE_ENGLAND, "TemplateEnglishCe");
+    testTemplate(underTest, "UACCET2", CE_WALES, "TemplateWelshAndEnglishCe");
+    testTemplate(underTest, "UACCET2W", CE_WALES_IN_WELSH, "TemplateWelshCe");
     assertThat(underTest.getTemplate("Wibble")).isNull();
   }
 

--- a/src/test/java/uk/gov/ons/census/notifyprocessor/utilities/TemplateMapperTest.java
+++ b/src/test/java/uk/gov/ons/census/notifyprocessor/utilities/TemplateMapperTest.java
@@ -14,6 +14,9 @@ public class TemplateMapperTest {
   private static final int INDIVIDUAL_RESPONSE_WALES = 22;
   private static final int INDIVIDUAL_RESPONSE_WALES_IN_WELSH = 23;
   private static final int INDIVIDUAL_RESPONSE_NI = 24;
+  private static final int CE_ENGLAND = 31;
+  private static final int CE_WALES = 32;
+  private static final int CE_WALES_IN_WELSH = 33;
 
   @Test
   public void testGetTemplate() {
@@ -33,6 +36,9 @@ public class TemplateMapperTest {
     testTemplate(underTest, "UACIT2", INDIVIDUAL_RESPONSE_WALES, "TemplateWelshAndEnglish");
     testTemplate(underTest, "UACIT2W", INDIVIDUAL_RESPONSE_WALES_IN_WELSH, "TemplateWelsh");
     testTemplate(underTest, "UACIT4", INDIVIDUAL_RESPONSE_NI, "TemplateNorthernIreland");
+    testTemplate(underTest, "UACCET1", CE_ENGLAND, "TemplateEnglish");
+    testTemplate(underTest, "UACCET2", CE_WALES, "TemplateWelshAndEnglish");
+    testTemplate(underTest, "UACCET2W", CE_WALES_IN_WELSH, "TemplateWelsh");
     assertThat(underTest.getTemplate("Wibble")).isNull();
   }
 


### PR DESCRIPTION
# Motivation and Context
New CE UAC fulfilment codes and new treatment ID sender and receiver codes need including 

# What has changed
New CE UAC fulfilment codes included
Updated READ.ME
Treatment IDs updated in application.yml
Fulfilment code to template mappings is 1-to-1 now
Updated test

# How to test?
Build repo along with others on card and run the ATs

# Links
https://trello.com/c/0zPdVGFQ/941-request-uac-via-sms-hh-ind-ce1-5
https://collaborate2.ons.gov.uk/confluence/pages/viewpage.action?spaceKey=SDC&title=UAC+by+SMS+Fulfilment+2021
https://collaborate2.ons.gov.uk/confluence/pages/viewpage.action?spaceKey=SDC&title=RM+Product+Library
