### PR TITLE
Use UUID data type for UUID data

### DIFF
--- a/src/main/java/uk/gov/ons/census/notifyprocessor/model/CaseDetails.java
+++ b/src/main/java/uk/gov/ons/census/notifyprocessor/model/CaseDetails.java
@@ -1,11 +1,12 @@
 package uk.gov.ons.census.notifyprocessor.model;
 
+import java.util.UUID;
 import lombok.Data;
 
 @Data
 public class CaseDetails {
 
-  private String caseId;
+  private UUID caseId;
 
   private String questionnaireType;
 }

--- a/src/main/java/uk/gov/ons/census/notifyprocessor/model/Event.java
+++ b/src/main/java/uk/gov/ons/census/notifyprocessor/model/Event.java
@@ -1,5 +1,6 @@
 package uk.gov.ons.census.notifyprocessor.model;
 
+import java.util.UUID;
 import lombok.Data;
 
 @Data
@@ -8,5 +9,5 @@ public class Event {
   private String source;
   private String channel;
   private String dateTime;
-  private String transactionId;
+  private UUID transactionId;
 }

--- a/src/main/java/uk/gov/ons/census/notifyprocessor/model/FulfilmentRequest.java
+++ b/src/main/java/uk/gov/ons/census/notifyprocessor/model/FulfilmentRequest.java
@@ -2,6 +2,7 @@ package uk.gov.ons.census.notifyprocessor.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import java.util.UUID;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
@@ -10,12 +11,12 @@ import lombok.NoArgsConstructor;
 public class FulfilmentRequest {
 
   @JsonInclude(Include.NON_NULL)
-  private String caseId;
+  private UUID caseId;
 
   private String fulfilmentCode;
 
   @JsonInclude(Include.NON_NULL)
-  private String individualCaseId;
+  private UUID individualCaseId;
 
   private Contact contact;
 }

--- a/src/main/java/uk/gov/ons/census/notifyprocessor/model/UacQidCreated.java
+++ b/src/main/java/uk/gov/ons/census/notifyprocessor/model/UacQidCreated.java
@@ -1,10 +1,11 @@
 package uk.gov.ons.census.notifyprocessor.model;
 
+import java.util.UUID;
 import lombok.Data;
 
 @Data
 public class UacQidCreated {
   private String uac;
   private String qid;
-  private String caseId;
+  private UUID caseId;
 }

--- a/src/main/java/uk/gov/ons/census/notifyprocessor/service/FulfilmentRequestService.java
+++ b/src/main/java/uk/gov/ons/census/notifyprocessor/service/FulfilmentRequestService.java
@@ -67,7 +67,7 @@ public class FulfilmentRequestService {
       return;
     }
 
-    String caseId = fulfilmentEvent.getPayload().getFulfilmentRequest().getCaseId();
+    UUID caseId = fulfilmentEvent.getPayload().getFulfilmentRequest().getCaseId();
 
     if (individualResponseRequestCodes.contains(fulfilmentCode)) {
       caseId = fulfilmentEvent.getPayload().getFulfilmentRequest().getIndividualCaseId();
@@ -90,7 +90,7 @@ public class FulfilmentRequestService {
     rabbitTemplate.convertAndSend(enrichedFulfilmentExchange, "", enrichedFulfilmentRequest);
   }
 
-  private UacQid getUacQidPair(int questionnaireType, String caseId) {
+  private UacQid getUacQidPair(int questionnaireType, UUID caseId) {
     UacQid uacqid = uacQidCache.getUacQidPair(questionnaireType);
 
     UacQidCreated uacQidCreated = new UacQidCreated();
@@ -101,7 +101,7 @@ public class FulfilmentRequestService {
     Event event = new Event();
     event.setType(RM_UAC_CREATED);
     event.setDateTime(DateTimeFormatter.ISO_DATE_TIME.format(OffsetDateTime.now(ZoneId.of("UTC"))));
-    event.setTransactionId(UUID.randomUUID().toString());
+    event.setTransactionId(UUID.randomUUID());
     ResponseManagementEvent responseManagementEvent = new ResponseManagementEvent();
     responseManagementEvent.setEvent(event);
     Payload payload = new Payload();

--- a/src/test/java/uk/gov/ons/census/notifyprocessor/messaging/FulfilmentRequestReceiverIT.java
+++ b/src/test/java/uk/gov/ons/census/notifyprocessor/messaging/FulfilmentRequestReceiverIT.java
@@ -7,6 +7,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import java.util.UUID;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.TimeUnit;
 import org.jeasy.random.EasyRandom;
@@ -73,7 +74,7 @@ public class FulfilmentRequestReceiverIT {
     responseManagementEvent.setEvent(new Event());
     responseManagementEvent.setPayload(new Payload());
     responseManagementEvent.getPayload().setFulfilmentRequest(new FulfilmentRequest());
-    responseManagementEvent.getPayload().getFulfilmentRequest().setCaseId("test caseId");
+    responseManagementEvent.getPayload().getFulfilmentRequest().setCaseId(UUID.randomUUID());
     responseManagementEvent.getPayload().getFulfilmentRequest().setFulfilmentCode("UACHHT1");
     responseManagementEvent.getPayload().getFulfilmentRequest().setContact(new Contact());
     responseManagementEvent.getPayload().getFulfilmentRequest().getContact().setTelNo("012345");
@@ -106,8 +107,7 @@ public class FulfilmentRequestReceiverIT {
         objectMapper.readValue(actualUacQidCreateMessage, ResponseManagementEvent.class);
     assertThat(actualRmUacQidCreateEvent.getEvent().getType()).isEqualTo(EventType.RM_UAC_CREATED);
     assertThat(actualRmUacQidCreateEvent.getPayload().getUacQidCreated().getCaseId())
-        .isEqualTo(
-            responseManagementEvent.getPayload().getFulfilmentRequest().getCaseId().toString());
+        .isEqualTo(responseManagementEvent.getPayload().getFulfilmentRequest().getCaseId());
     assertThat(actualRmUacQidCreateEvent.getPayload().getUacQidCreated().getQid())
         .isEqualTo(uacQid.getQid());
     assertThat(actualRmUacQidCreateEvent.getPayload().getUacQidCreated().getUac())


### PR DESCRIPTION
# Motivation and Context
Now using the UUID data type for UUID data.

# What has changed
Changes to a few models, the FulfilmentRequest service and a test

# How to test?
Build it and run it against the acceptance tests (master), with use-UUID-type-for-UUID-data branches of DDL, case-processor, case-api, action-scheduler, action-worker and action-processor.

# Links
- https://trello.com/c/r9qwqhaS