### PR TITLE
Use date type for dates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,10 @@
       <artifactId>notifications-java-client</artifactId>
       <version>3.9.2-RELEASE</version>
     </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-jsr310</artifactId>
+    </dependency>
 
     <!--    Test Dependencies below this point -->
     <dependency>

--- a/src/main/java/uk/gov/ons/census/notifyprocessor/config/AppConfig.java
+++ b/src/main/java/uk/gov/ons/census/notifyprocessor/config/AppConfig.java
@@ -3,6 +3,7 @@ package uk.gov.ons.census.notifyprocessor.config;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import java.util.TimeZone;
 import javax.annotation.PostConstruct;
 import org.springframework.amqp.core.AmqpAdmin;
@@ -30,6 +31,7 @@ public class AppConfig {
   @Bean
   public Jackson2JsonMessageConverter messageConverter() {
     ObjectMapper objectMapper = new ObjectMapper();
+    objectMapper.registerModule(new JavaTimeModule());
     objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
     objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
     return new Jackson2JsonMessageConverter(objectMapper);

--- a/src/main/java/uk/gov/ons/census/notifyprocessor/model/Event.java
+++ b/src/main/java/uk/gov/ons/census/notifyprocessor/model/Event.java
@@ -1,5 +1,6 @@
 package uk.gov.ons.census.notifyprocessor.model;
 
+import java.time.OffsetDateTime;
 import java.util.UUID;
 import lombok.Data;
 
@@ -8,6 +9,6 @@ public class Event {
   private EventType type;
   private String source;
   private String channel;
-  private String dateTime;
+  private OffsetDateTime dateTime;
   private UUID transactionId;
 }

--- a/src/main/java/uk/gov/ons/census/notifyprocessor/service/FulfilmentRequestService.java
+++ b/src/main/java/uk/gov/ons/census/notifyprocessor/service/FulfilmentRequestService.java
@@ -3,8 +3,6 @@ package uk.gov.ons.census.notifyprocessor.service;
 import static uk.gov.ons.census.notifyprocessor.model.EventType.RM_UAC_CREATED;
 
 import java.time.OffsetDateTime;
-import java.time.ZoneId;
-import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
@@ -96,7 +94,7 @@ public class FulfilmentRequestService {
 
     Event event = new Event();
     event.setType(RM_UAC_CREATED);
-    event.setDateTime(DateTimeFormatter.ISO_DATE_TIME.format(OffsetDateTime.now(ZoneId.of("UTC"))));
+    event.setDateTime(OffsetDateTime.now());
     event.setTransactionId(UUID.randomUUID());
     ResponseManagementEvent responseManagementEvent = new ResponseManagementEvent();
     responseManagementEvent.setEvent(event);

--- a/src/test/java/uk/gov/ons/census/notifyprocessor/messaging/FulfilmentRequestReceiverIT.java
+++ b/src/test/java/uk/gov/ons/census/notifyprocessor/messaging/FulfilmentRequestReceiverIT.java
@@ -6,6 +6,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import java.util.UUID;
 import java.util.concurrent.BlockingQueue;
@@ -44,6 +46,12 @@ public class FulfilmentRequestReceiverIT {
   private static final String MULTIPLE_QIDS_URL = "/multiple_qids";
   public static final String SMS_NOTIFY_API_URL = "/v2/notifications/sms";
   private static final String CASE_UAC_QID_CREATED_QUEUE = "case.uac-qid-created";
+  private static final ObjectMapper objectMapper = new ObjectMapper();
+
+  static {
+    objectMapper.registerModule(new JavaTimeModule());
+    objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+  }
 
   @Autowired private RabbitQueueHelper rabbitQueueHelper;
 
@@ -54,8 +62,6 @@ public class FulfilmentRequestReceiverIT {
 
   @Value("${queueconfig.fulfilment-routing-key}")
   private String caseProcessorFulfilmentRoutingKeyCase;
-
-  private ObjectMapper objectMapper = new ObjectMapper();
 
   @Before
   @Transactional


### PR DESCRIPTION
# Motivation and Context
We want to take advantage of Java's strong typing, and to use `OffsetDateTime` for date types, not strings.

# What has changed
Changed anywhere that was using a string for date/time/timestamp to use `OffsetDateTime`.

# How to test?
Run the ATs - should be zero regression.

# Links
Trello: https://trello.com/c/PbcNYiWe