### PR TITLE
Propagate RM_UAC_CREATED Event

### DIFF
--- a/src/main/java/uk/gov/ons/census/notifyprocessor/service/FulfilmentRequestService.java
+++ b/src/main/java/uk/gov/ons/census/notifyprocessor/service/FulfilmentRequestService.java
@@ -67,7 +67,13 @@ public class FulfilmentRequestService {
       caseId = fulfilmentEvent.getPayload().getFulfilmentRequest().getIndividualCaseId();
     }
 
-    UacQid uacqid = getUacQidPair(tuple.getQuestionnaireType(), caseId);
+    UacQid uacqid =
+        getUacQidPair(
+            tuple.getQuestionnaireType(),
+            caseId,
+            fulfilmentEvent.getEvent().getTransactionId(),
+            fulfilmentEvent.getEvent().getSource(),
+            fulfilmentEvent.getEvent().getChannel());
 
     EnrichedFulfilmentRequest enrichedFulfilmentRequest = new EnrichedFulfilmentRequest();
     enrichedFulfilmentRequest.setTemplateId(tuple.getTemplateId());
@@ -84,7 +90,8 @@ public class FulfilmentRequestService {
     rabbitTemplate.convertAndSend(enrichedFulfilmentExchange, "", enrichedFulfilmentRequest);
   }
 
-  private UacQid getUacQidPair(int questionnaireType, UUID caseId) {
+  private UacQid getUacQidPair(
+      int questionnaireType, UUID caseId, UUID transactionId, String source, String channel) {
     UacQid uacqid = uacQidCache.getUacQidPair(questionnaireType);
 
     UacQidCreated uacQidCreated = new UacQidCreated();
@@ -95,7 +102,9 @@ public class FulfilmentRequestService {
     Event event = new Event();
     event.setType(RM_UAC_CREATED);
     event.setDateTime(OffsetDateTime.now());
-    event.setTransactionId(UUID.randomUUID());
+    event.setTransactionId(transactionId);
+    event.setChannel(channel);
+    event.setSource(source);
     ResponseManagementEvent responseManagementEvent = new ResponseManagementEvent();
     responseManagementEvent.setEvent(event);
     Payload payload = new Payload();

--- a/src/test/java/uk/gov/ons/census/notifyprocessor/messaging/FulfilmentRequestReceiverIT.java
+++ b/src/test/java/uk/gov/ons/census/notifyprocessor/messaging/FulfilmentRequestReceiverIT.java
@@ -47,6 +47,7 @@ public class FulfilmentRequestReceiverIT {
   public static final String SMS_NOTIFY_API_URL = "/v2/notifications/sms";
   private static final String CASE_UAC_QID_CREATED_QUEUE = "case.uac-qid-created";
   private static final ObjectMapper objectMapper = new ObjectMapper();
+  private static final UUID TEST_TRANSACTION_ID = UUID.randomUUID();
 
   static {
     objectMapper.registerModule(new JavaTimeModule());
@@ -84,6 +85,9 @@ public class FulfilmentRequestReceiverIT {
     responseManagementEvent.getPayload().getFulfilmentRequest().setFulfilmentCode("UACHHT1");
     responseManagementEvent.getPayload().getFulfilmentRequest().setContact(new Contact());
     responseManagementEvent.getPayload().getFulfilmentRequest().getContact().setTelNo("012345");
+    responseManagementEvent.getEvent().setTransactionId(TEST_TRANSACTION_ID);
+    responseManagementEvent.getEvent().setChannel("TestChannel");
+    responseManagementEvent.getEvent().setSource("TestSource");
 
     UacQid uacQid = stubCreateUacQid(1);
 
@@ -112,6 +116,9 @@ public class FulfilmentRequestReceiverIT {
     ResponseManagementEvent actualRmUacQidCreateEvent =
         objectMapper.readValue(actualUacQidCreateMessage, ResponseManagementEvent.class);
     assertThat(actualRmUacQidCreateEvent.getEvent().getType()).isEqualTo(EventType.RM_UAC_CREATED);
+    assertThat(actualRmUacQidCreateEvent.getEvent().getTransactionId())
+        .isEqualTo(TEST_TRANSACTION_ID);
+
     assertThat(actualRmUacQidCreateEvent.getPayload().getUacQidCreated().getCaseId())
         .isEqualTo(responseManagementEvent.getPayload().getFulfilmentRequest().getCaseId());
     assertThat(actualRmUacQidCreateEvent.getPayload().getUacQidCreated().getQid())

--- a/src/test/java/uk/gov/ons/census/notifyprocessor/service/FulfilmentRequestServiceTest.java
+++ b/src/test/java/uk/gov/ons/census/notifyprocessor/service/FulfilmentRequestServiceTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
+import java.util.UUID;
 import org.jeasy.random.EasyRandom;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
@@ -19,6 +20,10 @@ import uk.gov.ons.census.notifyprocessor.utilities.TemplateMapper;
 import uk.gov.ons.census.notifyprocessor.utilities.TemplateMapper.Tuple;
 
 public class FulfilmentRequestServiceTest {
+
+  private static final String TEST_SOURCE = "TestSource";
+  private static final String TEST_CHANNEL = "TestChannel";
+  private static final UUID TEST_TRANSACTION_ID = UUID.randomUUID();
 
   @Test
   public void testProcessMessage() {
@@ -37,6 +42,9 @@ public class FulfilmentRequestServiceTest {
 
     ResponseManagementEvent event = easyRandom.nextObject(ResponseManagementEvent.class);
     event.getPayload().getFulfilmentRequest().setFulfilmentCode("UACHHT1");
+    event.getEvent().setTransactionId(TEST_TRANSACTION_ID);
+    event.getEvent().setSource(TEST_SOURCE);
+    event.getEvent().setChannel(TEST_CHANNEL);
 
     // When
     underTest.processMessage(event);
@@ -50,6 +58,10 @@ public class FulfilmentRequestServiceTest {
         .convertAndSend(eq("testOtherExchange"), eq(""), rmEventArgCaptor.capture());
     ResponseManagementEvent rmEvent = rmEventArgCaptor.getValue();
     assertThat(rmEvent.getEvent().getType()).isEqualTo(EventType.RM_UAC_CREATED);
+    assertThat(rmEvent.getEvent().getTransactionId()).isEqualTo(TEST_TRANSACTION_ID);
+    assertThat(rmEvent.getEvent().getSource()).isEqualTo(TEST_SOURCE);
+    assertThat(rmEvent.getEvent().getChannel()).isEqualTo(TEST_CHANNEL);
+
     assertThat(rmEvent.getPayload().getUacQidCreated().getQid()).isEqualTo(uacQid.getQid());
     assertThat(rmEvent.getPayload().getUacQidCreated().getUac()).isEqualTo(uacQid.getUac());
     assertThat(rmEvent.getPayload().getUacQidCreated().getCaseId())


### PR DESCRIPTION
# Motivation and Context
We have decided to take a more targeted approach to transaction IDs, and propagate them through where we've definitely needed them historically. We could be requested to disable the UAC from a respondents initial contact letter/reminder etc if they have misplaced it. This may allow us to disable only one rather than all against the case.

# What has changed
TransactionId/Source/Channel for fulfilment request now show in RM_UAC_CREATED event
Tests

# How to test?
Build and ensure it passes tests

# Links
https://trello.com/c/nwTaUBmB/1321-transaction-id-source-channel-propagate-from-notify-processor-on-rmuaccreated-events-5
