### PR TITLE
Remove bintray repo from Maven pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,21 +14,6 @@
     <version>2.2.7.RELEASE</version>
   </parent>
 
-  <profiles>
-    <profile>
-      <id>bintray</id>
-      <activation>
-        <activeByDefault>true</activeByDefault>
-      </activation>
-      <repositories>
-        <repository>
-          <id>notify-repo</id>
-          <url>https://dl.bintray.com/gov-uk-notify/maven</url>
-        </repository>
-      </repositories>
-    </profile>
-  </profiles>
-
   <properties>
     <maven.compiler.release>11</maven.compiler.release>
   </properties>


### PR DESCRIPTION
# Motivation and Context
Bintray is shutting down. Gov Notify have made their Maven dependency available from Maven Central, so we no longer need to use Bintray.

# What has changed
Removed Bintray repo.

# How to test?
Manually remove the uk.gov.services directory from your .m2 directory (usually in your home directory). Then, do a clean build.

You should see the following:
```
Downloading from central: https://repo.maven.apache.org/maven2/uk/gov/service/notify/notifications-java-client/3.9.2-RELEASE/notifications-java-client-3.9.2-RELEASE.pom
Downloaded from central: https://repo.maven.apache.org/maven2/uk/gov/service/notify/notifications-java-client/3.9.2-RELEASE/notifications-java-client-3.9.2-RELEASE.pom (7.9 kB at 14 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/uk/gov/service/notify/notifications-java-client/3.9.2-RELEASE/notifications-java-client-3.9.2-RELEASE.jar
Downloaded from central: https://repo.maven.apache.org/maven2/uk/gov/service/notify/notifications-java-client/3.9.2-RELEASE/notifications-java-client-3.9.2-RELEASE.jar (32 kB at 124 kB/s)
```

# Links
Trello: https://trello.com/c/O0YUHOYJ